### PR TITLE
SVG bounding box checks in SQL query, resolves GeoNet/mtr#10.

### DIFF
--- a/mtr-api/routes_test.go
+++ b/mtr-api/routes_test.go
@@ -66,7 +66,7 @@ var routes = wt.Requests{
 	// Delete all metrics typeID for a device
 	{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage", Method: "DELETE"},
 
-	// Save a metrics
+	// Save a metric
 	{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&time=2015-05-14T21:40:30Z&value=14100", Method: "PUT"},
 
 	// Should get a rate limit error for sends in the same minute


### PR DESCRIPTION
Added more logic to the SQL query for making the SVG plots to only use
points that fall within the bounding box of the SVG plot area.
The protobuf method doesn't use bbox so it hasn't been modified.