### PR TITLE
Now returning 404s for invalid URLs, and a route test for the /app page.

### DIFF
--- a/internal/mtr_const.go
+++ b/internal/mtr_const.go
@@ -36,7 +36,7 @@ const (
 	AvgMean   ID = 2001
 	MaxFifty  ID = 2002
 	MaxNinety ID = 2003
-	
+
 	// Data latency
 	Mean   ID = 3001
 	Fifty  ID = 3002
@@ -67,7 +67,7 @@ var idColours = map[int]string{
 	2001: "#ff0000",
 	2002: "#00ff00",
 	2003: "#0000ff",
-	
+
 	3001: "deepskyblue",
 	3002: "deeppink",
 	3003: "limegreen",
@@ -97,7 +97,7 @@ var idLabels = map[int]string{
 	2001: "Avg Mean",
 	2002: "Max Fifty",
 	2003: "Max Ninety",
-	
+
 	3001: "Mean",
 	3002: "Fifty",
 	3003: "Ninety",

--- a/mtr-ui/home.go
+++ b/mtr-ui/home.go
@@ -14,6 +14,11 @@ func homePageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resu
 		return res
 	}
 
+	// handle invalid endpoints
+	if r.URL.Path != "" && r.URL.Path != "/" {
+		return &weft.NotFound
+	}
+
 	// We create a page struct with variables to substitute into the loaded template
 	p := mtrUiPage{}
 	p.Border.Title = "GeoNet MTR - Home"

--- a/mtr-ui/routes_test.go
+++ b/mtr-ui/routes_test.go
@@ -50,6 +50,11 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/map/voltage"},
 	{ID: wt.L(), URL: "/map/ping"},
 
+	// applications page
+	{ID: wt.L(), URL: "/app"},
+	// this page uses the applicationID to construct img elements which are not validated:
+	{ID: wt.L(), URL: "/app/plot?applicationID=test-app"},
+
 	// tag page
 	{ID: wt.L(), URL: "/tag/"},
 	{ID: wt.L(), URL: "/tag/A-C"},


### PR DESCRIPTION
Resolves GeoNet/mtr#183.

Adds more strict URL checking and tests for the /app page.