### PR TITLE
Added tags with link to search on plot (data/plot, field/plot) pages.

### DIFF
--- a/mtr-ui/assets/tmpl/components.html
+++ b/mtr-ui/assets/tmpl/components.html
@@ -140,6 +140,18 @@
 
 
 {{define "field_plot"}}
+{{if .Tags}}
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <div class="h4">
+        Tags:&nbsp;
+        {{range .Tags}}
+        <a href="/search?tagQuery={{.}}">{{.}}</a>
+        {{end}}
+        </div>
+    </div>
+</div>
+{{end}}
 <div class="row">
     <div class="col-xs-12 col-md-12">
         <img src="{{.MtrApiUrl}}/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/>
@@ -169,6 +181,18 @@
 {{end}}
 
 {{define "data_plot"}}
+{{if .Tags}}
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <div class="h4">
+            Tags:&nbsp;
+            {{range .Tags}}
+            <a href="/search?tagQuery={{.}}">{{.}}</a>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}
 <div class="row">
     <div class="col-xs-12 col-md-12"><img src="{{.MtrApiUrl}}/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/></div>
 </div>

--- a/mtr-ui/ui_page.go
+++ b/mtr-ui/ui_page.go
@@ -21,6 +21,7 @@ type mtrUiPage struct {
 	Status        string
 	MtrApiUrl     string
 	Resolution    string
+	Tags          []string
 	fieldResult   []*mtrpb.FieldMetricSummary
 	dataResult    []*mtrpb.DataLatencySummary
 	param         string


### PR DESCRIPTION
The x position of tags doesn't looks ideally. However it's aligned to the client area's margin.
After 
go test -run TestPlotData
you can check the tags shown above svg for these pages:
/data/plot?siteID=TAUP&typeID=latency.strong
/field/plot?deviceID=gps-taupoairport&typeID=voltage