### PR TITLE
Scatter plot2

### DIFF
--- a/mtr-api/data_completeness.go
+++ b/mtr-api/data_completeness.go
@@ -280,8 +280,9 @@ func (a dataCompleteness) plot(siteID, typeID, resolution string, b *bytes.Buffe
 
 		pts = append(pts, pt)
 		p.SetLatest(pt, "deepskyblue")
-		p.AddSeries(ts.Series{Colour: "deepskyblue", Points: pts})
 	}
+
+	p.AddSeries(ts.Series{Colour: "deepskyblue", Points: pts})
 
 	if err = ts.Line.Draw(p, b); err != nil {
 		return weft.InternalServerError(err)

--- a/mtr-api/data_completeness.go
+++ b/mtr-api/data_completeness.go
@@ -140,7 +140,15 @@ func (a dataCompleteness) svg(r *http.Request, h http.Header, b *bytes.Buffer) *
 		if resolution == "" {
 			resolution = "minute"
 		}
-		if res := a.plot(v.Get("siteID"), v.Get("typeID"), resolution, b); !res.Ok {
+		if res := a.plot(v.Get("siteID"), v.Get("typeID"), resolution, ts.Line, b); !res.Ok {
+			return res
+		}
+	case "scatter":
+		resolution := v.Get("resolution")
+		if resolution == "" {
+			resolution = "minute"
+		}
+		if res := a.plot(v.Get("siteID"), v.Get("typeID"), resolution, ts.Scatter, b); !res.Ok {
 			return res
 		}
 	default:
@@ -157,7 +165,7 @@ func (a dataCompleteness) svg(r *http.Request, h http.Header, b *bytes.Buffer) *
 /*
 plot draws an svg plot to b.  Assumes f.loadPK has been called first.
 */
-func (a dataCompleteness) plot(siteID, typeID, resolution string, b *bytes.Buffer) *weft.Result {
+func (a dataCompleteness) plot(siteID, typeID, resolution string, plotter ts.SVGPlot, b *bytes.Buffer) *weft.Result {
 	var err error
 	// we need the sitePK often so read it once.
 	var sitePK int
@@ -284,7 +292,7 @@ func (a dataCompleteness) plot(siteID, typeID, resolution string, b *bytes.Buffe
 
 	p.AddSeries(ts.Series{Colour: "deepskyblue", Points: pts})
 
-	if err = ts.Line.Draw(p, b); err != nil {
+	if err = plotter.Draw(p, b); err != nil {
 		return weft.InternalServerError(err)
 	}
 

--- a/mtr-api/data_latency.go
+++ b/mtr-api/data_latency.go
@@ -167,7 +167,15 @@ func (a dataLatency) svg(r *http.Request, h http.Header, b *bytes.Buffer) *weft.
 		if resolution == "" {
 			resolution = "minute"
 		}
-		if res := a.plot(v.Get("siteID"), v.Get("typeID"), resolution, b); !res.Ok {
+		if res := a.plot(v.Get("siteID"), v.Get("typeID"), resolution, ts.Line, b); !res.Ok {
+			return res
+		}
+	case "scatter":
+		resolution := v.Get("resolution")
+		if resolution == "" {
+			resolution = "minute"
+		}
+		if res := a.plot(v.Get("siteID"), v.Get("typeID"), resolution, ts.Scatter, b); !res.Ok {
 			return res
 		}
 	default:
@@ -227,7 +235,7 @@ func (a dataLatency) csv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.
 /*
 plot draws an svg plot to b.  Assumes f.loadPK has been called first.
 */
-func (a dataLatency) plot(siteID, typeID, resolution string, b *bytes.Buffer) *weft.Result {
+func (a dataLatency) plot(siteID, typeID, resolution string, plotter ts.SVGPlot, b *bytes.Buffer) *weft.Result {
 	var err error
 	// we need the sitePK often so read it once.
 	var sitePK int
@@ -388,7 +396,7 @@ func (a dataLatency) plot(siteID, typeID, resolution string, b *bytes.Buffer) *w
 	labels = append(labels, ts.Label{Label: internal.Label(int(internal.Ninety)), Colour: internal.Colour(int(internal.Ninety))})
 	p.SetLabels(labels)
 
-	if err = ts.Line.Draw(p, b); err != nil {
+	if err = plotter.Draw(p, b); err != nil {
 		return weft.InternalServerError(err)
 	}
 

--- a/mtr-api/routes_test.go
+++ b/mtr-api/routes_test.go
@@ -164,6 +164,7 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&resolution=hour", Content: "image/svg+xml"},
 	{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&resolution=day", Status: http.StatusBadRequest, Surrogate: "max-age=86400"},
 	{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&plot=spark", Content: "image/svg+xml"},
+	{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&resolution=minute&plot=scatter", Content: "image/svg+xml"},
 
 	// Latest metrics as SVG map
 	//  These only pass with the map180 data in the DB.
@@ -285,12 +286,14 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&resolution=minute"},
 	{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&resolution=hour"},
 	{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&plot=spark"},
+	{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&resolution=minute&plot=scatter"},
 
 	// Completeness plots.
 	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=five_minutes"},
 	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=hour"},
 	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=twelve_hours"},
 	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&plot=spark"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=five_minutes&plot=scatter"},
 
 	// Tags
 

--- a/ts/plot_templates.go
+++ b/ts/plot_templates.go
@@ -77,6 +77,12 @@ var Line = SVGPlot{
 	height:   210,
 }
 
+var Scatter = SVGPlot{
+	template: template.Must(template.New("plot").Funcs(funcMap).Parse(plotBaseTemplate + scatterDotTemplate)),
+	width:    780,
+	height:   210,
+}
+
 var MixedAppMetrics = SVGPlot{
 	template: template.Must(template.New("plot").Funcs(funcMap).Parse(plotAppMetricsTemplate + plotAppMixedTemplate)),
 	width:    640,
@@ -185,6 +191,14 @@ const plotLineTemplate = `
 {{define "data"}}
 {{range .Data}}
 <polyline style="stroke: {{.Series.Colour}}; fill: none; stroke-width: 2px; stroke-linecap: round; stroke-linejoin: round" points="{{range .Pts}}{{.X}},{{.Y}} {{end}}" />
+{{end}}
+{{end}}`
+
+const scatterDotTemplate = `
+{{define "data"}}
+{{range .Data}}
+{{$Colour:=.Series.Colour}}
+{{range .Pts}}<circle cx="{{.X}}" cy="{{.Y}}" r="2" fill="none" stroke="{{$Colour}}"/>{{end}}
 {{end}}
 {{end}}`
 


### PR DESCRIPTION
Accepts "scatter" as "plot" parameter.
e.g.

/field/metric?deviceID=gps-taupoairport&typeID=voltage&plot=scatter
/data/latency?siteID=TAUP&typeID=latency.strong&plot=scatter
/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=five_minutes&plot=scatter