### PR TITLE
Implemented interactive graphs using dygraphs

### DIFF
--- a/mtr-ui/app_page.go
+++ b/mtr-ui/app_page.go
@@ -55,7 +55,7 @@ func appPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resul
 func appPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	var err error
 
-	if res := weft.CheckQuery(r, []string{"applicationID"}, []string{"resolution"}); !res.Ok {
+	if res := weft.CheckQuery(r, []string{"applicationID"}, []string{"resolution", "interactive"}); !res.Ok {
 		return res
 	}
 
@@ -68,7 +68,8 @@ func appPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.R
 	// get the applicationID and resolution params from the URL
 	p.pageParam(r.URL.Query())
 
-	if p.Resolution == "" {
+	// Resolution not required if we're in "interactive" mode otherwise default is minute
+	if p.Resolution == "" && !p.Interactive {
 		p.Resolution = "minute"
 	}
 

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -50,17 +50,28 @@ function showGraph(csvUrl, res, graphOptions, thresholds) {
 
     request.onload = function() {
         if (request.status == 200 || request.status == 404) {
-            // Success!
-            plotData(div, request.response, graphOptions, thresholds);
+            // Success but check for null data
+            var data = request.response;
+            if (!data) {
+                data = "no data\n0";
+                graphOptions.title = "No Data Found";
+            }
+
+            console.log("DEBUG", div, data, graphOptions, thresholds);
+            plotData(div, data, graphOptions, thresholds);
         } else {
             // We reached our target server, but it returned an error
-            throw "error loading csv";
+            //throw "error loading csv";
+            graphOptions.title = "Error fetching data: " + request.statusText;
+            plotData(div, "no data\n0", graphOptions, thresholds);
         }
     };
 
     request.onerror = function() {
         // There was a connection error of some sort
-        throw "error downloading CSV data";
+        //throw "error downloading CSV data";
+        graphOptions.title = "Error fetching data: " + request.statusText;
+        plotData(div, "no data\n0", graphOptions, thresholds);
     };
 
     request.send();

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -29,7 +29,7 @@ function plotData(div, csvData, graphOptions, thresholds) {
         graphOptions);
 }
 
-function showGraph(csvUrl, graphOptions, thresholds) {
+function showGraph(csvUrl, res, graphOptions, thresholds) {
     var graphElement = document.getElementById('graphdiv');
     var div = document.createElement('div');
     div.style.width = '90vw'; // use 90% of the available width (scales with changing width)
@@ -38,6 +38,11 @@ function showGraph(csvUrl, graphOptions, thresholds) {
     div.style.margin = '4px';
     // appending to parent div lets us plots as many graphs as we like
     graphElement.appendChild(div);
+
+    if (!res) {
+        res = "minute";
+    }
+    csvUrl += "&resolution=" + res;
 
     var request = new XMLHttpRequest();
     request.open('GET', csvUrl, true);

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -49,29 +49,29 @@ function showGraph(csvUrl, res, graphOptions, thresholds) {
     request.setRequestHeader ("Accept", "text/csv");
 
     request.onload = function() {
-        if (request.status == 200 || request.status == 404) {
+        if (request.status == 200) {
             // Success but check for null data
             var data = request.response;
             if (!data) {
-                data = "no data\n0";
-                graphOptions.title = "No Data Found";
+                data = "\n";
+                graphOptions.title += " [Error: No Data Found]";
             }
 
             console.log("DEBUG", div, data, graphOptions, thresholds);
             plotData(div, data, graphOptions, thresholds);
         } else {
-            // We reached our target server, but it returned an error
+            // We reached our target server, but it returned an error.  Plot a blank graph with the error message.
             //throw "error loading csv";
-            graphOptions.title = "Error fetching data: " + request.statusText;
-            plotData(div, "no data\n0", graphOptions, thresholds);
+            graphOptions.title += " [Error fetching data: " + request.statusText + "]";
+            plotData(div, "\n", graphOptions, thresholds);
         }
     };
 
     request.onerror = function() {
         // There was a connection error of some sort
         //throw "error downloading CSV data";
-        graphOptions.title = "Error fetching data: " + request.statusText;
-        plotData(div, "no data\n0", graphOptions, thresholds);
+        graphOptions.title += " [Error fetching data: " + request.statusText + "]";
+        plotData(div, "\n", graphOptions, thresholds);
     };
 
     request.send();

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -4,15 +4,7 @@ function utcToLocal(x) {
 	return Date.parse(x) - msOffset;
 }
 
-function plotData(csvData, graphOptions, thresholds) {
-    var graphElement = document.getElementById('graphdiv');
-    var div = document.createElement('div');
-    div.style.width = '90vw'; // use 90% of the available width (scales with changing width)
-    div.style.display = 'inline-block';
-    div.style.margin = '4px';
-    // appending to parent div lets us plots as many graphs as we like
-    graphElement.appendChild(div);
-
+function plotData(div, csvData, graphOptions, thresholds) {
     //Grey box for thresholds if specified:
     if (thresholds) {
         graphOptions.underlayCallback = function(canvas, area, g) {
@@ -47,6 +39,15 @@ function plotData(csvData, graphOptions, thresholds) {
 }
 
 function showGraph(csvUrl, graphOptions, thresholds) {
+    var graphElement = document.getElementById('graphdiv');
+    var div = document.createElement('div');
+    div.style.width = '90vw'; // use 90% of the available width (scales with changing width)
+    div.style.height = '40vh';
+    div.style.display = 'inline-block';
+    div.style.margin = '4px';
+    // appending to parent div lets us plots as many graphs as we like
+    graphElement.appendChild(div);
+
     var request = new XMLHttpRequest();
     request.open('GET', csvUrl, true);
     request.setRequestHeader ("Accept", "text/csv");
@@ -54,7 +55,7 @@ function showGraph(csvUrl, graphOptions, thresholds) {
     request.onload = function() {
         if (request.status == 200 || request.status == 404) {
             // Success!
-            plotData(request.response, graphOptions, thresholds);
+            plotData(div, request.response, graphOptions, thresholds);
         } else {
             // We reached our target server, but it returned an error
             throw "error loading csv";

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -1,0 +1,70 @@
+var msOffset = new Date().getTimezoneOffset()*60*1000; // offset in milliseconds
+
+function utcToLocal(x) {
+	return Date.parse(x) - msOffset;
+}
+
+function plotData(csvData, graphOptions, thresholds) {
+    var graphElement = document.getElementById('graphdiv');
+    var div = document.createElement('div');
+    div.style.width = '90vw'; // use 90% of the available width (scales with changing width)
+    div.style.display = 'inline-block';
+    div.style.margin = '4px';
+    // appending to parent div lets us plots as many graphs as we like
+    graphElement.appendChild(div);
+
+    //Grey box for thresholds if specified:
+    if (thresholds) {
+        graphOptions.underlayCallback = function(canvas, area, g) {
+          // convert coords to Dom x/y.  Only concerned with Y values
+          var bottom = g.toDomCoords(0, thresholds[0]);
+          var top = g.toDomCoords(0, thresholds[1]);
+
+          canvas.fillStyle = "rgba(200, 200, 200, 0.5)";
+          //start at (0,0) which is upper left, and make a box from bottom left to top right
+          canvas.fillRect(0, top[1], area.w + area.x, bottom[1]-top[1]);
+        }
+    }
+
+    // Make the default time plotting in local time
+    if (!graphOptions.xValueParser) {
+        graphOptions.xValueParser = utcToLocal;
+    }
+
+    var g = new Dygraph(
+        div,
+        csvData,
+        graphOptions);
+        // TODO: could use annotations to mark the values of the last sample(s)
+        //var annotations = [];
+        //annotations.push( {
+        //  series: 'mean',
+        //  x: "2016/06/26 23:23:58",
+        //  shortText: 'xyz',
+        //  text: 'Stock Market Crash'
+        //} );
+        //g.setAnnotations(annotations);
+}
+
+function showGraph(csvUrl, graphOptions, thresholds) {
+    var request = new XMLHttpRequest();
+    request.open('GET', csvUrl, true);
+    request.setRequestHeader ("Accept", "text/csv");
+
+    request.onload = function() {
+        if (request.status == 200 || request.status == 404) {
+            // Success!
+            plotData(request.response, graphOptions, thresholds);
+        } else {
+            // We reached our target server, but it returned an error
+            throw "error loading csv";
+        }
+    };
+
+    request.onerror = function() {
+        // There was a connection error of some sort
+        throw "error downloading CSV data";
+    };
+
+    request.send();
+}

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -18,24 +18,15 @@ function plotData(div, csvData, graphOptions, thresholds) {
         }
     }
 
-    // Make the default time plotting in local time
-    if (!graphOptions.xValueParser) {
-        graphOptions.xValueParser = utcToLocal;
-    }
+//    // Make the default time plotting in local time
+//    if (!graphOptions.xValueParser) {
+//        graphOptions.xValueParser = utcToLocal;
+//    }
 
     var g = new Dygraph(
         div,
         csvData,
         graphOptions);
-        // TODO: could use annotations to mark the values of the last sample(s)
-        //var annotations = [];
-        //annotations.push( {
-        //  series: 'mean',
-        //  x: "2016/06/26 23:23:58",
-        //  shortText: 'xyz',
-        //  text: 'Stock Market Crash'
-        //} );
-        //g.setAnnotations(annotations);
 }
 
 function showGraph(csvUrl, graphOptions, thresholds) {

--- a/mtr-ui/assets/tmpl/app_plot.html
+++ b/mtr-ui/assets/tmpl/app_plot.html
@@ -20,7 +20,7 @@
                 var counterOptions = {
                     title: 'Application - Metric Counters: (application ID: {{urlquery .ApplicationID}})',
                     //connectSeparatedPoints: true,
-                    xlabel: 'Local Time',
+                    xlabel: 'Date (UTC)',
                     ylabel: 'Count',
                     drawPoints: true,
                     pointSize: 2,
@@ -37,7 +37,7 @@
                 var timerOptions = {
                     title: 'Application - Metric Timers: (application ID: {{urlquery .ApplicationID}})',
                     //connectSeparatedPoints: true,
-                    xlabel: 'Local Time',
+                    xlabel: 'Date (UTC)',
                     ylabel: 'Time (ms)',
                     drawPoints: true,
                     pointSize: 2,
@@ -54,7 +54,7 @@
                 var memoryOptions = {
                     title: 'Application - Metric Memory: (application ID: {{urlquery .ApplicationID}})',
                     //connectSeparatedPoints: true,
-                    xlabel: 'Local Time',
+                    xlabel: 'Date (UTC)',
                     ylabel: 'Bytes',
                     drawPoints: true,
                     pointSize: 2,
@@ -71,7 +71,7 @@
                 var routineOptions = {
                     title: 'Application - Metric Routines: (application ID: {{urlquery .ApplicationID}})',
                     //connectSeparatedPoints: true,
-                    xlabel: 'Local Time',
+                    xlabel: 'Date (UTC)',
                     ylabel: 'Count',
                     drawPoints: true,
                     pointSize: 2,
@@ -88,7 +88,7 @@
                 var objectOptions = {
                     title: 'Application - Metric Memory Heap Objects: (application ID: {{urlquery .ApplicationID}})',
                     //connectSeparatedPoints: true,
-                    xlabel: 'Local Time',
+                    xlabel: 'Date (UTC)',
                     ylabel: 'Count',
                     drawPoints: true,
                     pointSize: 2,

--- a/mtr-ui/assets/tmpl/app_plot.html
+++ b/mtr-ui/assets/tmpl/app_plot.html
@@ -4,6 +4,109 @@
 
 <div class="row">
     <div class="col-xs-12 col-md-12">
+        {{if .Interactive}}
+        <div id="graphdiv" class="graph">
+            <script>
+                var now = new Date();
+                // sets initial zoom window
+                //var dateRange = [ new Date().setDate(now.getDate() - 1), now ];
+                var dateRange = null;
+
+                var res = {{urlquery .Resolution}};
+                if (!res) {
+                    res = "minute"
+                }
+
+                var counterOptions = {
+                    title: 'Application - Metric Counters: (application ID: {{urlquery .ApplicationID}})',
+                    //connectSeparatedPoints: true,
+                    xlabel: 'Local Time',
+                    ylabel: 'Count',
+                    drawPoints: true,
+                    pointSize: 2,
+                    rollPeriod: 1,
+                    showRoller: true,
+                    strokeWidth: 2,
+                    dateWindow: dateRange,
+                };
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=counters&resolution="+res,
+                            counterOptions,
+                            {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
+                );
+
+                var timerOptions = {
+                    title: 'Application - Metric Timers: (application ID: {{urlquery .ApplicationID}})',
+                    //connectSeparatedPoints: true,
+                    xlabel: 'Local Time',
+                    ylabel: 'Time (ms)',
+                    drawPoints: true,
+                    pointSize: 2,
+                    rollPeriod: 1,
+                    showRoller: true,
+                    strokeWidth: 2,
+                    dateWindow: dateRange,
+                };
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=timers&resolution="+res,
+                            timerOptions,
+                            {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
+                );
+
+                var memoryOptions = {
+                    title: 'Application - Metric Memory: (application ID: {{urlquery .ApplicationID}})',
+                    //connectSeparatedPoints: true,
+                    xlabel: 'Local Time',
+                    ylabel: 'Bytes',
+                    drawPoints: true,
+                    pointSize: 2,
+                    rollPeriod: 1,
+                    showRoller: true,
+                    strokeWidth: 2,
+                    dateWindow: dateRange,
+                };
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=memory&resolution="+res,
+                            memoryOptions,
+                            {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
+                );
+
+                var routineOptions = {
+                    title: 'Application - Metric Routines: (application ID: {{urlquery .ApplicationID}})',
+                    //connectSeparatedPoints: true,
+                    xlabel: 'Local Time',
+                    ylabel: 'Count',
+                    drawPoints: true,
+                    pointSize: 2,
+                    rollPeriod: 1,
+                    showRoller: true,
+                    strokeWidth: 2,
+                    dateWindow: dateRange,
+                };
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=routines&resolution="+res,
+                            routineOptions,
+                            {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
+                );
+
+                var objectOptions = {
+                    title: 'Application - Metric Memory Heap Objects: (application ID: {{urlquery .ApplicationID}})',
+                    //connectSeparatedPoints: true,
+                    xlabel: 'Local Time',
+                    ylabel: 'Count',
+                    drawPoints: true,
+                    pointSize: 2,
+                    rollPeriod: 1,
+                    showRoller: true,
+                    strokeWidth: 0.0, // draw points but not lines connecting them
+                    dateWindow: dateRange,
+                };
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=objects&resolution="+res,
+                            objectOptions,
+                            {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
+                );
+
+            </script>
+        </div>
+        {{template "app_plot_res" .}}
+
+        {{else}}
         <img src="{{.MtrApiUrl}}/app/metric?applicationID={{.ApplicationID}}&group=counters&resolution={{.Resolution}}" />
         {{template "app_plot_res" .}}
         <br>
@@ -21,3 +124,4 @@
         {{end}}
     </div>
 </div>
+{{end}}

--- a/mtr-ui/assets/tmpl/app_plot.html
+++ b/mtr-ui/assets/tmpl/app_plot.html
@@ -13,9 +13,6 @@
                 var dateRange = null;
 
                 var res = {{urlquery .Resolution}};
-                if (!res) {
-                    res = "minute"
-                }
 
                 var counterOptions = {
                     title: 'Application - Metric Counters: (application ID: {{urlquery .ApplicationID}})',
@@ -29,7 +26,8 @@
                     strokeWidth: 2,
                     dateWindow: dateRange,
                 };
-                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=counters&resolution="+res,
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=counters",
+                            res,
                             counterOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -46,7 +44,8 @@
                     strokeWidth: 2,
                     dateWindow: dateRange,
                 };
-                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=timers&resolution="+res,
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=timers",
+                            res,
                             timerOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -63,7 +62,8 @@
                     strokeWidth: 2,
                     dateWindow: dateRange,
                 };
-                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=memory&resolution="+res,
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=memory",
+                            res,
                             memoryOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -80,7 +80,8 @@
                     strokeWidth: 2,
                     dateWindow: dateRange,
                 };
-                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=routines&resolution="+res,
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=routines",
+                            res,
                             routineOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -97,7 +98,8 @@
                     strokeWidth: 0.0, // draw points but not lines connecting them
                     dateWindow: dateRange,
                 };
-                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=objects&resolution="+res,
+                showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=objects",
+                            res,
                             objectOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );

--- a/mtr-ui/assets/tmpl/app_plot.html
+++ b/mtr-ui/assets/tmpl/app_plot.html
@@ -7,13 +7,6 @@
         {{if .Interactive}}
         <div id="graphdiv" class="graph">
             <script>
-                var now = new Date();
-                // sets initial zoom window
-                //var dateRange = [ new Date().setDate(now.getDate() - 1), now ];
-                var dateRange = null;
-
-                var res = {{urlquery .Resolution}};
-
                 var counterOptions = {
                     title: 'Application - Metric Counters: (application ID: {{urlquery .ApplicationID}})',
                     //connectSeparatedPoints: true,
@@ -24,10 +17,9 @@
                     rollPeriod: 1,
                     showRoller: true,
                     strokeWidth: 2,
-                    dateWindow: dateRange,
                 };
                 showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=counters",
-                            res,
+                            {{urlquery .Resolution}},
                             counterOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -42,10 +34,9 @@
                     rollPeriod: 1,
                     showRoller: true,
                     strokeWidth: 2,
-                    dateWindow: dateRange,
                 };
                 showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=timers",
-                            res,
+                            {{urlquery .Resolution}},
                             timerOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -60,10 +51,9 @@
                     rollPeriod: 1,
                     showRoller: true,
                     strokeWidth: 2,
-                    dateWindow: dateRange,
                 };
                 showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=memory",
-                            res,
+                            {{urlquery .Resolution}},
                             memoryOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -78,10 +68,9 @@
                     rollPeriod: 1,
                     showRoller: true,
                     strokeWidth: 2,
-                    dateWindow: dateRange,
                 };
                 showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=routines",
-                            res,
+                            {{urlquery .Resolution}},
                             routineOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );
@@ -96,10 +85,9 @@
                     rollPeriod: 1,
                     showRoller: true,
                     strokeWidth: 0.0, // draw points but not lines connecting them
-                    dateWindow: dateRange,
                 };
                 showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=objects",
-                            res,
+                            {{urlquery .Resolution}},
                             objectOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}}
                 );

--- a/mtr-ui/assets/tmpl/border.html
+++ b/mtr-ui/assets/tmpl/border.html
@@ -9,6 +9,10 @@
     <title>{{ .Border.Title }}</title>
     <link rel="stylesheet" href="//static.geonet.org.nz/bootstrap/3.3.6/css/bootstrap.min.css">
 
+    {{ if .Interactive }}
+    <script src="//static.geonet.org.nz/dygraph/dygraph-combined.js"></script>
+    <script src="/js/graph.js"></script>
+    {{end}}
 
     <style>
 		.footer {
@@ -65,6 +69,11 @@
 			height:53px;
 			display:block;
 		}
+
+		.graph{
+			width: 100vw;
+		}
+
 		.linked {
 			padding: 10px;
 			margin: 0px 0;
@@ -196,7 +205,7 @@
     </div>
     <script src="//static.geonet.org.nz/jquery/js/jquery-1.11.3.min.js"></script>
     <script src="//static.geonet.org.nz/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-    <script type="text/javascript">
+    <script>
         $(document).keypress(function(e) {
             if(!$('#search_query').is(':focus')) {
                 if (e.charCode==47) {

--- a/mtr-ui/assets/tmpl/components.html
+++ b/mtr-ui/assets/tmpl/components.html
@@ -165,7 +165,7 @@
                 var graphOptions = {
                      title: 'Field Metrics (deviceID: {{urlquery .DeviceID}}, typeID: {{urlquery .TypeID}})',
                      //connectSeparatedPoints: true,
-                     xlabel: 'Local Time',
+                     xlabel: 'Date (UTC)',
                      ylabel: 'Latency (ms)',
                      drawPoints: true,
                      pointSize: 2,
@@ -271,7 +271,7 @@
         var graphOptions = {
              title: 'Data Latency (siteID: {{urlquery .SiteID}}, typeID: {{urlquery .TypeID}})',
              //connectSeparatedPoints: true,
-             xlabel: 'Local Time',
+             xlabel: 'Date (UTC)',
              ylabel: 'Latency (ms)',
              drawPoints: true,
              pointSize: 2,

--- a/mtr-ui/assets/tmpl/components.html
+++ b/mtr-ui/assets/tmpl/components.html
@@ -154,15 +154,50 @@
 {{end}}
 <div class="row">
     <div class="col-xs-12 col-md-12">
+        {{if .Interactive}}
+        <div id="graphdiv" class="graph">
+            <script type="text/javascript">
+                var res = {{urlquery .Resolution}};
+                if (!res) {
+                    res = "minute"
+                }
+
+                var graphOptions = {
+                     title: 'Field Metrics (deviceID: {{urlquery .DeviceID}}, typeID: {{urlquery .TypeID}})',
+                     //connectSeparatedPoints: true,
+                     xlabel: 'Local Time',
+                     ylabel: 'Latency (ms)',
+                     drawPoints: true,
+                     pointSize: 2,
+                     rollPeriod: 1,
+                     showRoller: true,
+                     strokeWidth: 2,
+                };
+
+                showGraph("/p/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution="+res,
+                            graphOptions,
+                            {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}});
+            </script>
+        </div>
+        {{else}}
         <img src="{{.MtrApiUrl}}/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/>
+        {{end}}
     </div>
 </div>
 <div class="row">
     <div class="col-xs-12 col-md-12">
         <ul class="nav nav-pills">
-            <li role="presentation" {{if eq .Resolution "minute"}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
-            <li role="presentation" {{if eq .Resolution "five_minutes"}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
-            <li role="presentation" {{if eq .Resolution "hour"}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
+        </ul>
+    </div>
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=full">All Data</a></li>
         </ul>
     </div>
 </div>
@@ -191,9 +226,17 @@
 <div class="row">
     <div class="col-xs-12 col-md-12">
         <ul class="nav nav-pills">
-            <li role="presentation" {{if eq .Resolution "minute"}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=minute">12 Hours</a></li>
-            <li role="presentation" {{if eq .Resolution "five_minutes"}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=five_minutes">48 Hours</a></li>
-            <li role="presentation" {{if eq .Resolution "hour"}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=minute">SVG 12 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=hour">28 Days</a></li>
+        </ul>
+    </div>
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=full">All Data</a></li>
         </ul>
     </div>
 </div>
@@ -213,23 +256,66 @@
 </div>
 {{end}}
 <div class="row">
+
+    {{if .Interactive }}
+
+    <br>
+    <div class="graph col-xs-12 col-md-12" id="graphdiv"></div>
+    <script>
+
+        var res = {{urlquery .Resolution}};
+        if (!res) {
+            res = "minute"
+        }
+
+        var graphOptions = {
+             title: 'Data Latency (siteID: {{urlquery .SiteID}}, typeID: {{urlquery .TypeID}})',
+             //connectSeparatedPoints: true,
+             xlabel: 'Local Time',
+             ylabel: 'Latency (ms)',
+             drawPoints: true,
+             pointSize: 2,
+             rollPeriod: 1, // the number of points "rolled" or averaged into one, can modify interactively
+             showRoller: true,
+             strokeWidth: 2,
+        };
+
+        showGraph("/p/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution="+res,
+                    graphOptions,
+                    {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}});
+    </script>
+
+    {{else}}
+
     <div class="col-xs-12 col-md-12"><img src="{{.MtrApiUrl}}/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/></div>
+
+    {{end}}
+
 </div>
 <div class="row">
     <div class="col-xs-12 col-md-12">
         <ul class="nav nav-pills">
-            <li role="presentation" {{if eq .Resolution "minute"}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
-            <li role="presentation" {{if eq .Resolution "five_minutes"}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
-            <li role="presentation" {{if eq .Resolution "hour"}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
+        </ul>
+    </div>
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=full">All Data</a></li>
         </ul>
     </div>
 </div>
+
 {{if .LatencyLog}}
 <div class="row">
     <div class="col-xs-12 col-md-12">
         {{$upper:=.LatencyLog.Upper}}
         {{$lower:=.LatencyLog.Lower}}
-        <h4>Uppeer:{{$upper}}, Lower:{{$lower}}</h4>
+        <h4>Upper:{{$upper}}, Lower:{{$lower}}</h4>
         <table class="history-log">
             <thead><tr><th>time</th><th>mean</th><th>fifty</th><th>ninety</th></tr></thead>
             <tbody>

--- a/mtr-ui/assets/tmpl/components.html
+++ b/mtr-ui/assets/tmpl/components.html
@@ -158,9 +158,6 @@
         <div id="graphdiv" class="graph">
             <script type="text/javascript">
                 var res = {{urlquery .Resolution}};
-                if (!res) {
-                    res = "minute"
-                }
 
                 var graphOptions = {
                      title: 'Field Metrics (deviceID: {{urlquery .DeviceID}}, typeID: {{urlquery .TypeID}})',
@@ -174,7 +171,8 @@
                      strokeWidth: 2,
                 };
 
-                showGraph("/p/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution="+res,
+                showGraph("/p/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}",
+                            res,
                             graphOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}});
             </script>
@@ -264,9 +262,6 @@
     <script>
 
         var res = {{urlquery .Resolution}};
-        if (!res) {
-            res = "minute"
-        }
 
         var graphOptions = {
              title: 'Data Latency (siteID: {{urlquery .SiteID}}, typeID: {{urlquery .TypeID}})',
@@ -280,7 +275,8 @@
              strokeWidth: 2,
         };
 
-        showGraph("/p/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution="+res,
+        showGraph("/p/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}",
+                    res,
                     graphOptions,
                     {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}});
     </script>

--- a/mtr-ui/assets/tmpl/components.html
+++ b/mtr-ui/assets/tmpl/components.html
@@ -157,8 +157,6 @@
         {{if .Interactive}}
         <div id="graphdiv" class="graph">
             <script type="text/javascript">
-                var res = {{urlquery .Resolution}};
-
                 var graphOptions = {
                      title: 'Field Metrics (deviceID: {{urlquery .DeviceID}}, typeID: {{urlquery .TypeID}})',
                      //connectSeparatedPoints: true,
@@ -172,7 +170,7 @@
                 };
 
                 showGraph("/p/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}",
-                            res,
+                            {{urlquery .Resolution}},
                             graphOptions,
                             {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}});
             </script>
@@ -260,9 +258,6 @@
     <br>
     <div class="graph col-xs-12 col-md-12" id="graphdiv"></div>
     <script>
-
-        var res = {{urlquery .Resolution}};
-
         var graphOptions = {
              title: 'Data Latency (siteID: {{urlquery .SiteID}}, typeID: {{urlquery .TypeID}})',
              //connectSeparatedPoints: true,
@@ -276,7 +271,7 @@
         };
 
         showGraph("/p/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}",
-                    res,
+                    {{urlquery .Resolution}},
                     graphOptions,
                     {{if .Thresholds}}[{{index .Thresholds 0}}, {{index .Thresholds 1}}]{{else}}null{{end}});
     </script>

--- a/mtr-ui/data_page.go
+++ b/mtr-ui/data_page.go
@@ -6,6 +6,7 @@ import (
 	"github.com/GeoNet/weft"
 	"github.com/golang/protobuf/proto"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 )
@@ -147,11 +148,10 @@ func dataPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.
 	// Set thresholds on plot by drawing a box in dygraph.  Protobuf contains all thresholds, so select ours
 	u := *mtrApiUrl
 	u.Path = "/data/latency/threshold"
-	// TODO: use these params when the API is updated
-	//params := url.Values{}
-	//params.Add("typeID", q.Get("typeID"))
-	//params.Add("siteID", q.Get("siteID"))
-	//u.RawQuery = params.Encode()
+	params := url.Values{}
+	params.Add("typeID", q.Get("typeID"))
+	params.Add("siteID", q.Get("siteID"))
+	u.RawQuery = params.Encode()
 
 	var protoData []byte
 	if protoData, err = getBytes(u.String(), "application/x-protobuf"); err != nil {
@@ -163,19 +163,8 @@ func dataPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.
 		return weft.InternalServerError(err)
 	}
 
-	// TODO: use this simpler logic when the API is updated
-	//if f.Result != nil && len(f.Result) >= 1 {
-	//	p.Thresholds = []int32{f.Result[0].Lower, f.Result[0].Upper}
-	//} else {
-	//	p.Thresholds = []int32{0, 0}
-	//}
-	if f.Result != nil {
-		// TODO: modify mtr-api to accept options for typeID and siteID to allow querying of a single item
-		for _, row := range f.Result {
-			if row.SiteID == q.Get("siteID") && row.TypeID == q.Get("typeID") {
-				p.Thresholds = []int32{row.Lower, row.Upper}
-			}
-		}
+	if f.Result != nil && len(f.Result) >= 1 {
+		p.Thresholds = []int32{f.Result[0].Lower, f.Result[0].Upper}
 	} else {
 		p.Thresholds = []int32{0, 0}
 	}

--- a/mtr-ui/field_page.go
+++ b/mtr-ui/field_page.go
@@ -142,6 +142,40 @@ func fieldPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft
 		return weft.InternalServerError(err)
 	}
 
+	// Set thresholds on plot by drawing a box in dygraph.  Protobuf contains all thresholds, so select ours
+	u := *mtrApiUrl
+	u.Path = "/field/metric/threshold"
+	// TODO: modify /field/metric/threshold in mtr-api to accept deviceID and typeID
+	//params := url.Values{}
+	//params.Add("deviceID", q.Get("deviceID"))
+	//params.Add("typeID", q.Get("typeID"))
+	//u.RawQuery = params.Encode()
+
+	var err error
+	var protoData []byte
+	if protoData, err = getBytes(u.String(), "application/x-protobuf"); err != nil {
+		return weft.InternalServerError(err)
+	}
+
+	var f mtrpb.FieldMetricThresholdResult
+	if err = proto.Unmarshal(protoData, &f); err != nil {
+		return weft.InternalServerError(err)
+	}
+
+	// TODO: use this simpler logic when mtr-api accepts deviceID and typeID
+	////if f.Result != nil && len(f.Result) >= 1 {
+	////      p.Thresholds = []int32{f.Result[0].Lower, f.Result[0].Upper}
+	////} else {
+	////      p.Thresholds = []int32{0, 0}
+	////}
+	if f.Result != nil {
+		for _, row := range f.Result {
+			if row.DeviceID == p.DeviceID && row.TypeID == p.TypeID {
+				p.Thresholds = []int32{row.Lower, row.Upper}
+			}
+		}
+	}
+
 	if err := fieldTemplate.ExecuteTemplate(b, "border", p); err != nil {
 		return weft.InternalServerError(err)
 	}

--- a/mtr-ui/field_page.go
+++ b/mtr-ui/field_page.go
@@ -119,7 +119,7 @@ func fieldDevicesPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *w
 }
 
 func fieldPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution"}); !res.Ok {
+	if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution", "interactive"}); !res.Ok {
 		return res
 	}
 	p := mtrUiPage{}
@@ -133,7 +133,8 @@ func fieldPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft
 		return weft.InternalServerError(err)
 	}
 
-	if p.Resolution == "" {
+	// Resolution not required if we're in "interactive" mode otherwise default is minute
+	if p.Resolution == "" && !p.Interactive {
 		p.Resolution = "minute"
 	}
 

--- a/mtr-ui/map_page.go
+++ b/mtr-ui/map_page.go
@@ -10,9 +10,10 @@ import (
 
 type mapPage struct {
 	page
-	ActiveTab string
-	MtrApiUrl string
-	TypeID    string
+	ActiveTab   string
+	MtrApiUrl   string
+	TypeID      string
+	Interactive bool
 }
 
 func mapPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {

--- a/mtr-ui/metric_handler.go
+++ b/mtr-ui/metric_handler.go
@@ -12,6 +12,7 @@ type metricDetailPage struct {
 	page
 	MtrApiUrl    *url.URL
 	MetricDetail metricDetail
+	Interactive  bool
 }
 
 type metricDetail struct {

--- a/mtr-ui/routes_test.go
+++ b/mtr-ui/routes_test.go
@@ -26,6 +26,7 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&resolution=minute"},
 	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&resolution=five_minutes"},
 	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&resolution=hour"},
+	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&interactive=true"},
 	{ID: wt.L(), URL: "/data/metrics"},
 	{ID: wt.L(), URL: "/data/metrics?typeID=latency.gnss.1hz"},
 	{ID: wt.L(), URL: "/data/metrics?typeID=latency.gnss.1hz&status=good"},

--- a/mtr-ui/search.go
+++ b/mtr-ui/search.go
@@ -16,6 +16,7 @@ type searchPage struct {
 	MtrApiUrl       *url.URL
 	TagName         string
 	MatchingMetrics matchingMetrics
+	Interactive     bool
 }
 
 type matchingMetrics []metricInfo

--- a/mtr-ui/tag_page.go
+++ b/mtr-ui/tag_page.go
@@ -9,10 +9,11 @@ import (
 
 type tagPage struct {
 	page
-	ActiveTab string
-	Path      string
-	TagTabs   []string
-	Tags      []string
+	ActiveTab   string
+	Path        string
+	TagTabs     []string
+	Tags        []string
+	Interactive bool
 }
 
 var tagGrouper = []string{"ABC", "DEF", "GHI", "JKL", "MNO", "POR", "STU", "VWXYZ", "0123456789"}

--- a/mtr-ui/ui_page.go
+++ b/mtr-ui/ui_page.go
@@ -21,7 +21,9 @@ type mtrUiPage struct {
 	Status        string
 	MtrApiUrl     string
 	Resolution    string
+	Thresholds    []int32
 	Tags          []string
+	Interactive   bool
 	fieldResult   []*mtrpb.FieldMetricSummary
 	dataResult    []*mtrpb.DataLatencySummary
 	FieldLog      *mtrpb.FieldMetricResult
@@ -124,6 +126,8 @@ func (p *mtrUiPage) pageParam(q url.Values) int {
 	}
 
 	p.Resolution = q.Get("resolution")
+
+	p.Interactive = q.Get("interactive") == "true"
 	return n
 }
 


### PR DESCRIPTION
Lots of modifications, now including our own js file and using a proxy
for the csv endpoints from mtr-api.  Investigated using protobufs from
javascript but it was bringing in a lot of dependencies so opted for CSV.
These graphs are available on all pages currently displaying SVG plots.

This is a large PR and I expect a fair bit of discussion.  I'm wondering what everyone's thoughts are on everything but especially:

* The use of the Interactive page struct element to determine if we're using interactive graphs
* The way I'm calling the JS code.  I'm new to JS so I could have missed a much better approach, possibly jquery.
* The way I'm getting the CSV data from the mtr-api.  I'm using a local proxy and XMLHttpRequest to get the data (async).  @sorennh mentioned jquery but my approach was to get it working first then improve it.
* The Dygraphs are using the "resolution" parameter because some of the data were getting pretty large and load times were unacceptable.  There are probably many different ways of solving this, any ideas are welcome.
* The buttons for 12 hours / 48 hours / 28 days / etc. look pretty ugly right now but I'm hoping we can replace this layout with something more pleasing.  The templates for these buttons are getting a bit large too.

I realise this isn't using the new weft.toml syntax but hopefully I can get it merged before @gclitheroe makes those changes!