### PR TITLE
Add API docs from weft.toml

### DIFF
--- a/mtr-api/assets/api-docs/index.html
+++ b/mtr-api/assets/api-docs/index.html
@@ -1,0 +1,2008 @@
+
+	
+	<html>
+	<head>
+	<meta charset="utf-8"/>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
+	<title></title>
+	<link rel="stylesheet" href="https://static.geonet.org.nz/bootstrap/3.3.6/css/bootstrap.min.css">
+	<style>
+	body { padding-top: 60px; }
+	a.anchor { 
+		display: block; position: relative; top: -60px; visibility: hidden; 
+	}
+
+	.panel-height {
+		height: 150px; 
+		overflow-y: scroll;
+	}
+
+	.footer {
+		margin-top: 20px;
+		padding: 20px 0 20px;
+		border-top: 1px solid #e5e5e5;
+	}
+
+	.footer p {
+		text-align: center;
+	}
+
+	#logo{position:relative;}
+	#logo li{margin:0;padding:0;list-style:none;position:absolute;top:0;}
+	#logo li a span
+	{
+		position: absolute;
+		left: -10000px;
+	}
+
+	#gns li, #gns a
+	{
+		float: left;
+		display:block;
+		height: 90px;
+		width: 54px;
+	}
+
+	#gns{left:-20px;height:90px;width:54px;}
+	#gns{background:url('http://static.geonet.org.nz/geonet-2.0.2/images/logos.png') -0px -0px;}
+
+	#eqc li, #eqc a
+	{
+		display:block;
+		height: 61px;
+		width: 132px;
+	}
+
+	#eqc{right:0px;height:79px;width:132px;}
+	#eqc{background:url('http://static.geonet.org.nz/geonet-2.0.2/images/logos.png') -0px -312px;}
+
+	#ccby li, #ccby a
+	{
+		display:block;
+		height: 15px;
+		width: 80px;
+	}
+	#ccby{left:15px;height:15px;width:80px; }
+	#ccby{background:url('http://static.geonet.org.nz/geonet-2.0.2/images/logos.png') -0px -100px;}
+
+	#geonet{
+		background:url('http://static.geonet.org.nz/geonet-2.0.2/images/logos.png') 0px -249px; 
+		width:137px; 
+		height:53px;
+		display:block;
+	}
+	</style>
+	</head>
+	<body>
+	<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+	<div class="container">
+	<div class="navbar-header">
+	<a class="navbar-brand" href="http://geonet.org.nz">GeoNet</a>
+	</div>
+	</div>
+	</div>
+
+	<div class="container-fluid">
+	
+	<div class="alert alert-danger" role="alert">So you found this API just laying around on the internet and that's cool.
+	If you're seeing this message then we still view this as experimental or beta so if you use this thing you found
+	then please be aware that we may change it or take it away without warning.  If you have some feed back on the 
+	API functionality then please write your comment on a box of New Zealand craft IPA and mail it to us.  
+	Multiple submissions welcome.</div>
+	
+	
+
+	<h1 class="page-header">MTR API</h1>
+	<p class="lead">Welcome to the MTR API.</p>
+
+	<p>The GeoNet project makes all its data and images freely available.
+	Please ensure you have read and understood our 
+	<a href="http://info.geonet.org.nz/x/BYIW">Data Policy</a> and <a href="http://info.geonet.org.nz/x/EIIW">Disclaimer</a> 
+	before using any of these services.</p>
+
+	
+
+	<h3 class="page-header">Endpoints</h3>
+
+	<p>The following endpoints are available:</p>
+	<ul>
+	
+	<li><a href="#app">App</a> - Find applications.</li>
+	
+	<li><a href="#appmetric">App Metric</a> - application metrics.</li>
+	
+	<li><a href="#applicationcounter">Application Counter</a> - application counters.</li>
+	
+	<li><a href="#applicationmetric">Application Metric</a> - application metrics.</li>
+	
+	<li><a href="#applicationtimer">Application Timer</a> - application timers.</li>
+	
+	<li><a href="#datacompleteness">Data Completeness</a> - completeness for data.</li>
+	
+	<li><a href="#datacompletenesssummary">Data Completeness Summary</a> - summary of data completeness.</li>
+	
+	<li><a href="#datacompletenesstag">Data Completeness Tag</a> - tag data completeness metrics.</li>
+	
+	<li><a href="#datalatency">Data Latency</a> - latency for data.</li>
+	
+	<li><a href="#datalatencysummary">Data Latency Summary</a> - summary for data latency.</li>
+	
+	<li><a href="#datalatencytag">Data Latency Tag</a> - tag data latency metrics.</li>
+	
+	<li><a href="#datalatencythreshold">Data Latency Threshold</a> - set thresholds on data latency.</li>
+	
+	<li><a href="#datasite">Data Site</a> - sites for data.</li>
+	
+	<li><a href="#datatype">Data Type</a> - types for data.</li>
+	
+	<li><a href="#fielddevice">Field Device</a> - field devices.</li>
+	
+	<li><a href="#fieldmetric">Field Metric</a> - field metrics.</li>
+	
+	<li><a href="#fieldmetricsummary">Field Metric Summary</a> - Field metric summaries.</li>
+	
+	<li><a href="#fieldmetrictag">Field Metric Tag</a> - tags for field metrics.</li>
+	
+	<li><a href="#fieldmetricthreshold">Field Metric Threshold</a> - thresholds for field metrics.</li>
+	
+	<li><a href="#fieldmodel">Field Model</a> - models for field devices.</li>
+	
+	<li><a href="#fieldstate">Field State</a> - state for field devices.</li>
+	
+	<li><a href="#fieldstatetag">Field State Tag</a> - tags can be added to field state.</li>
+	
+	<li><a href="#fieldtype">Field Type</a> - field metric types.</li>
+	
+	<li><a href="#tag">Tag</a> - find tags.</li>
+	
+	<li><a href="#tag">Tag</a> - Tags can be added to metrics.</li>
+	
+	</ul>
+
+	<p>All requests should be made over HTTPS.</p>
+
+	<h3 class="page-header">Versioning</h3>
+
+	<p>API queries may be versioned via the Accept header.
+	Please specify the <code>Accept</code> header for your request exactly as specified for the endpoint query you are using.</p>
+
+	<p>If you don't specify an Accept header with a version then your request will be routed to the current highest API version of the query
+	or the default route.</p>
+	
+	<h3 class="page-header">Compression</h3>
+
+	<p>The response for a query can be compressed.  If your client can handle a compressed response then the
+	reduced download size is a great benifit.  Gzip compression is supported.  You can request a compressed response
+	by including <code>gzip</code> in your <code>Accept-Encoding</code> header.</p>
+
+	<h3 class="page-header">Bugs</h3>
+
+	<p>The code that provide these services is available at <a href="https://github.com/GeoNet/mtr">https://github.com/GeoNet/mtr</a>  If you believe
+	you have found a bug please raise an issue or pull request there. 
+	Alternatively <a href="http://info.geonet.org.nz/x/JYAO">contact us</a> detailing the issue.</p>
+
+	
+	<a id="app" class="anchor"></a>
+	<h3 class="page-header">App</h3>
+	<p class="lead">Find applications.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/app</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	
+	<a id="appmetric" class="anchor"></a>
+	<h3 class="page-header">App Metric</h3>
+	<p class="lead">application metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/app/metric</dd>
+	<dt>Accept</dt><dd>image/svg&#43;xml</dd>
+	<dt>Default</dt><dd>default for GET with unmatched Accept.</dd>
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>applicationID</dt><dd>[string] the application identifier - must be unique across all applications.</dd><dt>group</dt><dd>[string] the metric group e.g., timers.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>sourceID</dt><dd>[string] source identifier for the metrics, often the function name.</dd><dt>yrange</dt><dd>[string] yrange for the plot e.g., 0,300</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/app/metric</dd>
+	<dt>Accept</dt><dd>text/csv</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>applicationID</dt><dd>[string] the application identifier - must be unique across all applications.</dd><dt>group</dt><dd>[string] the metric group e.g., timers.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>sourceID</dt><dd>[string] source identifier for the metrics, often the function name.</dd></dl>
+	
+
+	
+
+	
+	
+	<a id="applicationcounter" class="anchor"></a>
+	<h3 class="page-header">Application Counter</h3>
+	<p class="lead">application counters.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/application/counter</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>applicationID</dt><dd>[string] the application identifier - must be unique across all applications.</dd><dt>count</dt><dd>[int] the metric count</dd><dt>instanceID</dt><dd>[string] instance identifier for the metrics, often the host or container name.</dd><dt>time</dt><dd>[string] RFC3339 formatted time</dd><dt>typeID</dt><dd>[int] the type identifier - must be mtr.internal.ID.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="applicationmetric" class="anchor"></a>
+	<h3 class="page-header">Application Metric</h3>
+	<p class="lead">application metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/application/metric</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>applicationID</dt><dd>[string] the application identifier - must be unique across all applications.</dd><dt>instanceID</dt><dd>[string] instance identifier for the metrics, often the host or container name.</dd><dt>time</dt><dd>[string] RFC3339 formatted time</dd><dt>typeID</dt><dd>[int] the type identifier - must be mtr.internal.ID.</dd><dt>value</dt><dd>[int64] the metric value.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="applicationtimer" class="anchor"></a>
+	<h3 class="page-header">Application Timer</h3>
+	<p class="lead">application timers.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/application/timer</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>applicationID</dt><dd>[string] the application identifier - must be unique across all applications.</dd><dt>average</dt><dd>[int] the average time (ms).</dd><dt>count</dt><dd>[int] the metric count</dd><dt>fifty</dt><dd>[int] the fiftieth percentile time (ms).</dd><dt>instanceID</dt><dd>[string] instance identifier for the metrics, often the host or container name.</dd><dt>ninety</dt><dd>[int] the ninetieth percentile time (ms).</dd><dt>sourceID</dt><dd>[string] source identifier for the metrics, often the function name.</dd><dt>time</dt><dd>[string] RFC3339 formatted time</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="datacompleteness" class="anchor"></a>
+	<h3 class="page-header">Data Completeness</h3>
+	<p class="lead">completeness for data.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness</dd>
+	<dt>Accept</dt><dd>image/svg&#43;xml</dd>
+	<dt>Default</dt><dd>default for GET with unmatched Accept.</dd>
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>plot</dt><dd>[string] the plot style.</dd><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>yrange</dt><dd>[string] yrange for the plot e.g., 0,300</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>count</dt><dd>[int] the metric count</dd><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>time</dt><dd>[string] RFC3339 formatted time</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="datacompletenesssummary" class="anchor"></a>
+	<h3 class="page-header">Data Completeness Summary</h3>
+	<p class="lead">summary of data completeness.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness/summary</dd>
+	<dt>Accept</dt><dd>image/svg&#43;xml</dd>
+	<dt>Default</dt><dd>default for GET with unmatched Accept.</dd>
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness/summary</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+	
+	<a id="datacompletenesstag" class="anchor"></a>
+	<h3 class="page-header">Data Completeness Tag</h3>
+	<p class="lead">tag data completeness metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness/tag</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/completeness/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="datalatency" class="anchor"></a>
+	<h3 class="page-header">Data Latency</h3>
+	<p class="lead">latency for data.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency</dd>
+	<dt>Accept</dt><dd>image/svg&#43;xml</dd>
+	<dt>Default</dt><dd>default for GET with unmatched Accept.</dd>
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>plot</dt><dd>[string] the plot style.</dd><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>yrange</dt><dd>[string] yrange for the plot e.g., 0,300</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency</dd>
+	<dt>Accept</dt><dd>text/csv</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>mean</dt><dd>[int] the mean time (ms).</dd><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>time</dt><dd>[string] RFC3339 formatted time</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>fifty</dt><dd>[int] the fiftieth percentile time (ms).</dd><dt>max</dt><dd>[int] the max time (ms).</dd><dt>min</dt><dd>[int] the min time (ms).</dd><dt>ninety</dt><dd>[int] the ninetieth percentile time (ms).</dd></dl>
+	
+
+	
+
+	
+	
+	<a id="datalatencysummary" class="anchor"></a>
+	<h3 class="page-header">Data Latency Summary</h3>
+	<p class="lead">summary for data latency.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/summary</dd>
+	<dt>Accept</dt><dd>image/svg&#43;xml</dd>
+	<dt>Default</dt><dd>default for GET with unmatched Accept.</dd>
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>bbox</dt><dd>[string] the bbox for the map</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd><dt>width</dt><dd>[int] the width for the map</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/summary</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+	
+	<a id="datalatencytag" class="anchor"></a>
+	<h3 class="page-header">Data Latency Tag</h3>
+	<p class="lead">tag data latency metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/tag</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="datalatencythreshold" class="anchor"></a>
+	<h3 class="page-header">Data Latency Threshold</h3>
+	<p class="lead">set thresholds on data latency.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/threshold</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/threshold</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/latency/threshold</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>lower</dt><dd>[int] the lower bound</dd><dt>siteID</dt><dd>[string] the site identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd><dt>upper</dt><dd>[int] the upper bound</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="datasite" class="anchor"></a>
+	<h3 class="page-header">Data Site</h3>
+	<p class="lead">sites for data.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/site</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>siteID</dt><dd>[string] the site identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/site</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/site</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>latitude</dt><dd>[float64] the latitude</dd><dt>longitude</dt><dd>[float64] the longitude</dd><dt>siteID</dt><dd>[string] the site identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="datatype" class="anchor"></a>
+	<h3 class="page-header">Data Type</h3>
+	<p class="lead">types for data.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/data/type</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	
+	<a id="fielddevice" class="anchor"></a>
+	<h3 class="page-header">Field Device</h3>
+	<p class="lead">field devices.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/device</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/device</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/device</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>latitude</dt><dd>[float64] the latitude</dd><dt>longitude</dt><dd>[float64] the longitude</dd><dt>modelID</dt><dd>[string] the model identifier - used with deviceID.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldmetric" class="anchor"></a>
+	<h3 class="page-header">Field Metric</h3>
+	<p class="lead">field metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric</dd>
+	<dt>Accept</dt><dd>image/svg&#43;xml</dd>
+	<dt>Default</dt><dd>default for GET with unmatched Accept.</dd>
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>plot</dt><dd>[string] the plot style.</dd><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric</dd>
+	<dt>Accept</dt><dd>text/csv</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>time</dt><dd>[string] RFC3339 formatted time</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd><dt>value</dt><dd>[int] the metric value.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldmetricsummary" class="anchor"></a>
+	<h3 class="page-header">Field Metric Summary</h3>
+	<p class="lead">Field metric summaries.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/summary</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/summary</dd>
+	<dt>Accept</dt><dd>image/svg&#43;xml</dd>
+	<dt>Default</dt><dd>default for GET with unmatched Accept.</dd>
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>bbox</dt><dd>[string] the bbox for the map</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd><dt>width</dt><dd>[int] the width for the map</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/summary</dd>
+	<dt>Accept</dt><dd>application/vnd.geo&#43;json</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldmetrictag" class="anchor"></a>
+	<h3 class="page-header">Field Metric Tag</h3>
+	<p class="lead">tags for field metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/tag</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+	<h4>Optional Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldmetricthreshold" class="anchor"></a>
+	<h3 class="page-header">Field Metric Threshold</h3>
+	<p class="lead">thresholds for field metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/threshold</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/threshold</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/metric/threshold</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>lower</dt><dd>[int] the lower bound</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd><dt>upper</dt><dd>[int] the upper bound</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldmodel" class="anchor"></a>
+	<h3 class="page-header">Field Model</h3>
+	<p class="lead">models for field devices.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/model</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>modelID</dt><dd>[string] the model identifier - used with deviceID.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/model</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/model</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>modelID</dt><dd>[string] the model identifier - used with deviceID.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldstate" class="anchor"></a>
+	<h3 class="page-header">Field State</h3>
+	<p class="lead">state for field devices.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/state</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/state</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/state</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>time</dt><dd>[string] RFC3339 formatted time</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd><dt>value</dt><dd>[bool] the state.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldstatetag" class="anchor"></a>
+	<h3 class="page-header">Field State Tag</h3>
+	<p class="lead">tags can be added to field state.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/state/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/state/tag</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/state/tag</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+	<h4>Required Query Parameters:</h4>
+	<dl class="dl-horizontal"><dt>deviceID</dt><dd>[string] the device identifier.</dd><dt>tag</dt><dd>[string] a short tag</dd><dt>typeID</dt><dd>[string] the metric type identifier.</dd></dl>
+	
+
+	
+
+	
+
+	
+	
+	<a id="fieldtype" class="anchor"></a>
+	<h3 class="page-header">Field Type</h3>
+	<p class="lead">field metric types.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/field/type</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	
+	<a id="tag" class="anchor"></a>
+	<h3 class="page-header">Tag</h3>
+	<p class="lead">find tags.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/tag</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	
+	<a id="tag" class="anchor"></a>
+	<h3 class="page-header">Tag</h3>
+	<p class="lead">Tags can be added to metrics.</p>
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: DELETE</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/tag/(tag)</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+	<h4>URI Parameter:</h4>
+	<dl class="dl-horizontal"><dt>tag</dt><dd>[string] a short tag</dd></dl>
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: GET</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/tag/(tag)</dd>
+	<dt>Accept</dt><dd>application/x-protobuf</dd>
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+	<h4>URI Parameter:</h4>
+	<dl class="dl-horizontal"><dt>tag</dt><dd>[string] a short tag</dd></dl>
+	
+
+	
+
+	
+
+	
+
+	
+	<div class="panel panel-primary">
+	<div class="panel-heading">Method: PUT</div>
+	<div class="panel-body">
+
+	<dl class="dl-horizontal">
+	<dt>URI</dt><dd>/tag/(tag)</dd>
+	
+	
+	</dl>
+	</div>
+	</div>
+	<p></p>
+	
+
+	
+	<h4>URI Parameter:</h4>
+	<dl class="dl-horizontal"><dt>tag</dt><dd>[string] a short tag</dd></dl>
+	
+
+	
+
+	
+
+	
+
+	
+	
+
+	
+	<div id="footer" class="footer">
+	<div class="row">
+	<div class="col-sm-3 hidden-xs">
+	<ul id="logo">
+	<li id="geonet"><a target="_blank" href="http://www.geonet.org.nz"><span>GeoNet</span></a></li>
+	</ul>            
+	</div>
+
+	<div class="col-sm-6">
+	<p>GeoNet is a collaboration between the <a target="_blank" href="http://www.eqc.govt.nz">Earthquake Commission</a> and <a target="_blank" href="http://www.gns.cri.nz/">GNS Science</a>.</p>
+	<p><a target="_blank" href="http://info.geonet.org.nz/x/loYh">about</a> | <a target="_blank" href="http://info.geonet.org.nz/x/JYAO">contact</a> | <a target="_blank" href="http://info.geonet.org.nz/x/RYAo">privacy</a> | <a target="_blank" href="http://info.geonet.org.nz/x/EIIW">disclaimer</a> </p>
+	<p>GeoNet content is copyright <a target="_blank" href="http://www.gns.cri.nz/">GNS Science</a> and is licensed under a <a rel="license" target="_blank" href="http://creativecommons.org/licenses/by/3.0/nz/">Creative Commons Attribution 3.0 New Zealand License</a></p>
+	</div>
+
+	<div  class="col-sm-2 hidden-xs">
+	<ul id="logo">
+	<li id="eqc"><a target="_blank" href="http://www.eqc.govt.nz" ><span>EQC</span></a></li>
+	</ul>
+	</div>
+	<div  class="col-sm-1 hidden-xs">
+	<ul id="logo">
+	<li id="gns"><a target="_blank" href="http://www.gns.cri.nz"><span>GNS Science</span></a></li>
+	</ul>  
+	</div>
+	</div>
+
+	<div class="row">
+	<div class="col-sm-1 col-sm-offset-5 hidden-xs">
+	<ul id="logo">
+	<li id="ccby"><a href="http://creativecommons.org/licenses/by/3.0/nz/" ><span>CC-BY</span></a></li>
+	</ul>
+	</div>
+	</div>
+
+	</div>
+	</div>
+	</body>
+	</html>
+	
+	

--- a/mtr-api/handlers_auto.go
+++ b/mtr-api/handlers_auto.go
@@ -6,85 +6,54 @@ package main
 import (
 	"bytes"
 	"github.com/GeoNet/weft"
+	"io/ioutil"
 	"net/http"
 )
 
 var mux = http.NewServeMux()
 
 func init() {
-	mux.HandleFunc("/tag/", weft.MakeHandlerAPI(tagsHandler))
-	mux.HandleFunc("/tag", weft.MakeHandlerAPI(tagHandler))
+	mux.HandleFunc("/api-docs", weft.MakeHandlerPage(docHandler))
 	mux.HandleFunc("/app", weft.MakeHandlerAPI(appHandler))
 	mux.HandleFunc("/app/metric", weft.MakeHandlerAPI(appmetricHandler))
-	mux.HandleFunc("/application/metric", weft.MakeHandlerAPI(applicationmetricHandler))
 	mux.HandleFunc("/application/counter", weft.MakeHandlerAPI(applicationcounterHandler))
+	mux.HandleFunc("/application/metric", weft.MakeHandlerAPI(applicationmetricHandler))
 	mux.HandleFunc("/application/timer", weft.MakeHandlerAPI(applicationtimerHandler))
-	mux.HandleFunc("/field/metric", weft.MakeHandlerAPI(fieldmetricHandler))
-	mux.HandleFunc("/field/model", weft.MakeHandlerAPI(fieldmodelHandler))
-	mux.HandleFunc("/field/device", weft.MakeHandlerAPI(fielddeviceHandler))
-	mux.HandleFunc("/field/type", weft.MakeHandlerAPI(fieldtypeHandler))
-	mux.HandleFunc("/field/metric/summary", weft.MakeHandlerAPI(fieldmetricsummaryHandler))
-	mux.HandleFunc("/field/metric/threshold", weft.MakeHandlerAPI(fieldmetricthresholdHandler))
-	mux.HandleFunc("/field/metric/tag", weft.MakeHandlerAPI(fieldmetrictagHandler))
-	mux.HandleFunc("/field/state", weft.MakeHandlerAPI(fieldstateHandler))
-	mux.HandleFunc("/field/state/tag", weft.MakeHandlerAPI(fieldstatetagHandler))
-	mux.HandleFunc("/data/site", weft.MakeHandlerAPI(datasiteHandler))
-	mux.HandleFunc("/data/type", weft.MakeHandlerAPI(datatypeHandler))
+	mux.HandleFunc("/data/completeness", weft.MakeHandlerAPI(datacompletenessHandler))
+	mux.HandleFunc("/data/completeness/summary", weft.MakeHandlerAPI(datacompletenesssummaryHandler))
+	mux.HandleFunc("/data/completeness/tag", weft.MakeHandlerAPI(datacompletenesstagHandler))
 	mux.HandleFunc("/data/latency", weft.MakeHandlerAPI(datalatencyHandler))
 	mux.HandleFunc("/data/latency/summary", weft.MakeHandlerAPI(datalatencysummaryHandler))
 	mux.HandleFunc("/data/latency/tag", weft.MakeHandlerAPI(datalatencytagHandler))
 	mux.HandleFunc("/data/latency/threshold", weft.MakeHandlerAPI(datalatencythresholdHandler))
-	mux.HandleFunc("/data/completeness", weft.MakeHandlerAPI(datacompletenessHandler))
-	mux.HandleFunc("/data/completeness/summary", weft.MakeHandlerAPI(datacompletenesssummaryHandler))
-	mux.HandleFunc("/data/completeness/tag", weft.MakeHandlerAPI(datacompletenesstagHandler))
+	mux.HandleFunc("/data/site", weft.MakeHandlerAPI(datasiteHandler))
+	mux.HandleFunc("/data/type", weft.MakeHandlerAPI(datatypeHandler))
+	mux.HandleFunc("/field/device", weft.MakeHandlerAPI(fielddeviceHandler))
+	mux.HandleFunc("/field/metric", weft.MakeHandlerAPI(fieldmetricHandler))
+	mux.HandleFunc("/field/metric/summary", weft.MakeHandlerAPI(fieldmetricsummaryHandler))
+	mux.HandleFunc("/field/metric/tag", weft.MakeHandlerAPI(fieldmetrictagHandler))
+	mux.HandleFunc("/field/metric/threshold", weft.MakeHandlerAPI(fieldmetricthresholdHandler))
+	mux.HandleFunc("/field/model", weft.MakeHandlerAPI(fieldmodelHandler))
+	mux.HandleFunc("/field/state", weft.MakeHandlerAPI(fieldstateHandler))
+	mux.HandleFunc("/field/state/tag", weft.MakeHandlerAPI(fieldstatetagHandler))
+	mux.HandleFunc("/field/type", weft.MakeHandlerAPI(fieldtypeHandler))
+	mux.HandleFunc("/tag", weft.MakeHandlerAPI(tagHandler))
+	mux.HandleFunc("/tag/", weft.MakeHandlerAPI(tagsHandler))
 }
 
-func tagsHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+func docHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	switch r.Method {
 	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return tagProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
+		by, err := ioutil.ReadFile("assets/api-docs/index.html")
+		if err != nil {
+			return weft.InternalServerError(err)
 		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-			return res
-		}
-		return tagPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-			return res
-		}
-		return tagDelete(r, h, b)
+		b.Write(by)
+		return &weft.StatusOK
 	default:
 		return &weft.MethodNotAllowed
 	}
 }
-
-func tagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return tagsProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
 func appHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	switch r.Method {
 	case "GET":
@@ -108,36 +77,24 @@ func appmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Res
 	case "GET":
 		switch r.Header.Get("Accept") {
 		case "image/svg+xml":
-			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"resolution", "yrange", "sourceID"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"resolution", "sourceID", "yrange"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "image/svg+xml")
 			return appMetricSvg(r, h, b)
 		case "text/csv":
-			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"sourceID", "resolution"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"resolution", "sourceID"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "text/csv")
 			return appMetricCsv(r, h, b)
 		default:
-			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"resolution", "yrange", "sourceID"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"resolution", "sourceID", "yrange"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "image/svg+xml")
 			return appMetricSvg(r, h, b)
 		}
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func applicationmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"applicationID", "instanceID", "typeID", "time", "value"}, []string{}); !res.Ok {
-			return res
-		}
-		return applicationMetricPut(r, h, b)
 	default:
 		return &weft.MethodNotAllowed
 	}
@@ -146,7 +103,7 @@ func applicationmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *
 func applicationcounterHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	switch r.Method {
 	case "PUT":
-		if res := weft.CheckQuery(r, []string{"applicationID", "instanceID", "typeID", "time", "count"}, []string{}); !res.Ok {
+		if res := weft.CheckQuery(r, []string{"applicationID", "count", "instanceID", "time", "typeID"}, []string{}); !res.Ok {
 			return res
 		}
 		return applicationCounterPut(r, h, b)
@@ -155,451 +112,25 @@ func applicationcounterHandler(r *http.Request, h http.Header, b *bytes.Buffer) 
 	}
 }
 
+func applicationmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"applicationID", "instanceID", "time", "typeID", "value"}, []string{}); !res.Ok {
+			return res
+		}
+		return applicationMetricPut(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
 func applicationtimerHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	switch r.Method {
 	case "PUT":
-		if res := weft.CheckQuery(r, []string{"applicationID", "instanceID", "sourceID", "time", "average", "count", "fifty", "ninety"}, []string{}); !res.Ok {
+		if res := weft.CheckQuery(r, []string{"applicationID", "average", "count", "fifty", "instanceID", "ninety", "sourceID", "time"}, []string{}); !res.Ok {
 			return res
 		}
 		return applicationTimerPut(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldMetricProto(r, h, b)
-		case "image/svg+xml":
-			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"plot", "resolution"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return fieldMetricSvg(r, h, b)
-		case "text/csv":
-			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "text/csv")
-			return fieldMetricCsv(r, h, b)
-		default:
-			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"plot", "resolution"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return fieldMetricSvg(r, h, b)
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID", "time", "value"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldMetricPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldMetricDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldmodelHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldModelProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"modelID"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldModelPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"modelID"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldModelDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fielddeviceHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldDeviceProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"deviceID", "modelID", "latitude", "longitude"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldDevicePut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"deviceID"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldDeviceDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldtypeHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldTypeProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldmetricsummaryHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{"typeID"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldLatestProto(r, h, b)
-		case "image/svg+xml":
-			if res := weft.CheckQuery(r, []string{"bbox", "width", "typeID"}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return fieldLatestSvg(r, h, b)
-		case "application/vnd.geo+json":
-			if res := weft.CheckQuery(r, []string{"typeID"}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/vnd.geo+json")
-			return fieldLatestGeoJSON(r, h, b)
-		default:
-			if res := weft.CheckQuery(r, []string{"bbox", "width", "typeID"}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return fieldLatestSvg(r, h, b)
-		}
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldmetricthresholdHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldThresholdProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID", "lower", "upper"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldThresholdPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldThresholdDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldmetrictagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{"deviceID", "typeID"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldMetricTagProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID", "tag"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldMetricTagPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID", "tag"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldMetricTagDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldstateHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldStateProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID", "time", "value"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldStatePut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldStateDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func fieldstatetagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return fieldStateTagProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID", "tag"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldStateTagPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"deviceID", "typeID", "tag"}, []string{}); !res.Ok {
-			return res
-		}
-		return fieldStateTagDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func datasiteHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return dataSiteProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"siteID", "latitude", "longitude"}, []string{}); !res.Ok {
-			return res
-		}
-		return dataSitePut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"siteID"}, []string{}); !res.Ok {
-			return res
-		}
-		return dataSiteDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func datatypeHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return dataTypeProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func datalatencyHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "image/svg+xml":
-			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return dataLatencySvg(r, h, b)
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"resolution"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return dataLatencyProto(r, h, b)
-		case "text/csv":
-			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"resolution"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "text/csv")
-			return dataLatencyCsv(r, h, b)
-		default:
-			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return dataLatencySvg(r, h, b)
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID", "time", "mean"}, []string{"min", "max", "fifty", "ninety"}); !res.Ok {
-			return res
-		}
-		return dataLatencyPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{}); !res.Ok {
-			return res
-		}
-		return dataLatencyDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func datalatencysummaryHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "image/svg+xml":
-			if res := weft.CheckQuery(r, []string{"bbox", "width", "typeID"}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return dataLatencySummarySvg(r, h, b)
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{"typeID"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return dataLatencySummaryProto(r, h, b)
-		default:
-			if res := weft.CheckQuery(r, []string{"bbox", "width", "typeID"}, []string{}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "image/svg+xml")
-			return dataLatencySummarySvg(r, h, b)
-		}
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func datalatencytagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{"siteID", "typeID"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return dataLatencyTagProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID", "tag"}, []string{}); !res.Ok {
-			return res
-		}
-		return dataLatencyTagPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID", "tag"}, []string{}); !res.Ok {
-			return res
-		}
-		return dataLatencyTagDelete(r, h, b)
-	default:
-		return &weft.MethodNotAllowed
-	}
-}
-
-func datalatencythresholdHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	switch r.Method {
-	case "GET":
-		switch r.Header.Get("Accept") {
-		case "application/x-protobuf":
-			if res := weft.CheckQuery(r, []string{}, []string{"typeID", "siteID"}); !res.Ok {
-				return res
-			}
-			h.Set("Content-Type", "application/x-protobuf")
-			return dataLatencyThresholdProto(r, h, b)
-		default:
-			return &weft.NotAcceptable
-		}
-	case "PUT":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID", "lower", "upper"}, []string{}); !res.Ok {
-			return res
-		}
-		return dataLatencyThresholdPut(r, h, b)
-	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{}); !res.Ok {
-			return res
-		}
-		return dataLatencyThresholdDelete(r, h, b)
 	default:
 		return &weft.MethodNotAllowed
 	}
@@ -610,20 +141,20 @@ func datacompletenessHandler(r *http.Request, h http.Header, b *bytes.Buffer) *w
 	case "GET":
 		switch r.Header.Get("Accept") {
 		case "image/svg+xml":
-			if res := weft.CheckQuery(r, []string{"typeID", "siteID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "image/svg+xml")
 			return dataCompletenessSvg(r, h, b)
 		default:
-			if res := weft.CheckQuery(r, []string{"typeID", "siteID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "image/svg+xml")
 			return dataCompletenessSvg(r, h, b)
 		}
 	case "PUT":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID", "time", "count"}, []string{}); !res.Ok {
+		if res := weft.CheckQuery(r, []string{"count", "siteID", "time", "typeID"}, []string{}); !res.Ok {
 			return res
 		}
 		return dataCompletenessPut(r, h, b)
@@ -679,15 +210,499 @@ func datacompletenesstagHandler(r *http.Request, h http.Header, b *bytes.Buffer)
 			return &weft.NotAcceptable
 		}
 	case "PUT":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID", "tag"}, []string{}); !res.Ok {
+		if res := weft.CheckQuery(r, []string{"siteID", "tag", "typeID"}, []string{}); !res.Ok {
 			return res
 		}
 		return dataCompletenessTagPut(r, h, b)
 	case "DELETE":
-		if res := weft.CheckQuery(r, []string{"siteID", "typeID", "tag"}, []string{}); !res.Ok {
+		if res := weft.CheckQuery(r, []string{"siteID", "tag", "typeID"}, []string{}); !res.Ok {
 			return res
 		}
 		return dataCompletenessTagDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func datalatencyHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "image/svg+xml":
+			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return dataLatencySvg(r, h, b)
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"resolution"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return dataLatencyProto(r, h, b)
+		case "text/csv":
+			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"resolution"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/csv")
+			return dataLatencyCsv(r, h, b)
+		default:
+			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"plot", "resolution", "yrange"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return dataLatencySvg(r, h, b)
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"mean", "siteID", "time", "typeID"}, []string{"fifty", "max", "min", "ninety"}); !res.Ok {
+			return res
+		}
+		return dataLatencyPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return dataLatencyDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func datalatencysummaryHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "image/svg+xml":
+			if res := weft.CheckQuery(r, []string{"bbox", "typeID", "width"}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return dataLatencySummarySvg(r, h, b)
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{"typeID"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return dataLatencySummaryProto(r, h, b)
+		default:
+			if res := weft.CheckQuery(r, []string{"bbox", "typeID", "width"}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return dataLatencySummarySvg(r, h, b)
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func datalatencytagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{"siteID", "typeID"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return dataLatencyTagProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"siteID", "tag", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return dataLatencyTagPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"siteID", "tag", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return dataLatencyTagDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func datalatencythresholdHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{"siteID", "typeID"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return dataLatencyThresholdProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"lower", "siteID", "typeID", "upper"}, []string{}); !res.Ok {
+			return res
+		}
+		return dataLatencyThresholdPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return dataLatencyThresholdDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func datasiteHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return dataSiteProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"latitude", "longitude", "siteID"}, []string{}); !res.Ok {
+			return res
+		}
+		return dataSitePut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"siteID"}, []string{}); !res.Ok {
+			return res
+		}
+		return dataSiteDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func datatypeHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return dataTypeProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fielddeviceHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldDeviceProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"deviceID", "latitude", "longitude", "modelID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldDevicePut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"deviceID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldDeviceDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldMetricProto(r, h, b)
+		case "image/svg+xml":
+			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"plot", "resolution"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return fieldMetricSvg(r, h, b)
+		case "text/csv":
+			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "text/csv")
+			return fieldMetricCsv(r, h, b)
+		default:
+			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"plot", "resolution"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return fieldMetricSvg(r, h, b)
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"deviceID", "time", "typeID", "value"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldMetricPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldMetricDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldmetricsummaryHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{"typeID"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldLatestProto(r, h, b)
+		case "image/svg+xml":
+			if res := weft.CheckQuery(r, []string{"bbox", "typeID", "width"}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return fieldLatestSvg(r, h, b)
+		case "application/vnd.geo+json":
+			if res := weft.CheckQuery(r, []string{"typeID"}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/vnd.geo+json")
+			return fieldLatestGeoJSON(r, h, b)
+		default:
+			if res := weft.CheckQuery(r, []string{"bbox", "typeID", "width"}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "image/svg+xml")
+			return fieldLatestSvg(r, h, b)
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldmetrictagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{"deviceID", "typeID"}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldMetricTagProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"deviceID", "tag", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldMetricTagPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"deviceID", "tag", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldMetricTagDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldmetricthresholdHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldThresholdProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"deviceID", "lower", "typeID", "upper"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldThresholdPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldThresholdDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldmodelHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldModelProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"modelID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldModelPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"modelID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldModelDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldstateHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldStateProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"deviceID", "time", "typeID", "value"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldStatePut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldStateDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldstatetagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldStateTagProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{"deviceID", "tag", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldStateTagPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{"deviceID", "tag", "typeID"}, []string{}); !res.Ok {
+			return res
+		}
+		return fieldStateTagDelete(r, h, b)
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func fieldtypeHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return fieldTypeProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func tagHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return tagsProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	default:
+		return &weft.MethodNotAllowed
+	}
+}
+
+func tagsHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
+	switch r.Method {
+	case "GET":
+		switch r.Header.Get("Accept") {
+		case "application/x-protobuf":
+			if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+				return res
+			}
+			h.Set("Content-Type", "application/x-protobuf")
+			return tagProto(r, h, b)
+		default:
+			return &weft.NotAcceptable
+		}
+	case "PUT":
+		if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+			return res
+		}
+		return tagPut(r, h, b)
+	case "DELETE":
+		if res := weft.CheckQuery(r, []string{}, []string{}); !res.Ok {
+			return res
+		}
+		return tagDelete(r, h, b)
 	default:
 		return &weft.MethodNotAllowed
 	}

--- a/mtr-api/weft.toml
+++ b/mtr-api/weft.toml
@@ -1,44 +1,191 @@
+title = "MTR API"
+repo = "https://github.com/GeoNet/mtr"
+
+[query.applicationID]
+description = "the application identifier - must be unique across all applications."
+type = "string"
+
+[query.group]
+description = "the metric group e.g., timers."
+type = "string"
+
+[query.resolution]
+description = "resolution for the plot e.g., five_minutes"
+type = "string"
+
+[query.yrange]
+description = "yrange for the plot e.g., 0,300"
+type = "string"
+
+[query.sourceID]
+description = "source identifier for the metrics, often the function name."
+type = "string"
+
+[query.instanceID]
+description = "instance identifier for the metrics, often the host or container name."
+type = "string"
+
+[query."application.typeID"]
+id = "typeID"
+description = "the type identifier - must be mtr.internal.ID."
+type = "int"
+
+[query.time]
+description = "RFC3339 formatted time"
+type = "string"
+
+[query."application.value"]
+id = "value"
+description = "the metric value."
+type = "int64"
+
+[query.count]
+description = "the metric count"
+type = "int"
+
+[query.average]
+description = "the average time (ms)."
+type = "int"
+
+[query.max]
+description = "the max time (ms)."
+type = "int"
+
+[query.min]
+description = "the min time (ms)."
+type = "int"
+
+[query.mean]
+description = "the mean time (ms)."
+type = "int"
+
+[query.fifty]
+description = "the fiftieth percentile time (ms)."
+type = "int"
+
+[query.ninety]
+description = "the ninetieth percentile time (ms)."
+type = "int"
+
+[query.modelID]
+description = "the model identifier - used with deviceID."
+type = "string"
+
+[query.deviceID]
+description = "the device identifier."
+type = "string"
+
+[query."field.typeID"]
+id = "typeID"
+description = "the metric type identifier."
+type = "string"
+
+[query.plot]
+description = "the plot style."
+type = "string"
+
+[query."field.value"]
+id = "value"
+description = "the metric value."
+type = "int"
+
+[query.latitude]
+description = "the latitude"
+type = "float64"
+
+[query.longitude]
+description = "the longitude"
+type = "float64"
+
+[query.bbox]
+description = "the bbox for the map"
+type = "string"
+
+[query.width]
+description = "the width for the map"
+type = "int"
+
+[query.upper]
+description = "the upper bound"
+type = "int"
+
+[query.lower]
+description = "the lower bound"
+type = "int"
+
+[query.tag]
+description = "a short tag"
+type = "string"
+
+[query."state.value"]
+id = "value"
+description = "the state."
+type = "bool"
+
+[query.siteID]
+description = "the site identifier."
+type = "string"
+
+
 [[endpoint]]
 uri = "/tag/"
+title = "Tag"
+description = "Tags can be added to metrics."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "tagProto"
 accept = "application/x-protobuf"
+parameter = "tag"
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "tagPut"
+parameter = "tag"
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "tagDelete"
+parameter = "tag"
 
 
 [[endpoint]]
 uri = "/tag"
+title = "Tag"
+description = "find tags."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "tagsProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/app"
+title = "App"
+description = "Find applications."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "appIdProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/app/metric"
+title = "App Metric"
+description = "application metrics."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "appMetricSvg"
 accept = "image/svg+xml"
 default = true
 required = ["applicationID", "group"]
 optional = ["resolution", "yrange", "sourceID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "appMetricCsv"
 accept = "text/csv"
 required = ["applicationID", "group"]
@@ -47,332 +194,429 @@ optional = ["sourceID", "resolution"]
 
 [[endpoint]]
 uri = "/application/metric"
+title = "Application Metric"
+description = "application metrics."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "applicationMetricPut"
-required = ["applicationID", "instanceID", "typeID", "time", "value"]
+required = ["applicationID", "instanceID", "application.typeID", "time", "application.value"]
 
 
 [[endpoint]]
 uri = "/application/counter"
+title = "Application Counter"
+description = "application counters."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "applicationCounterPut"
-required = ["applicationID", "instanceID", "typeID", "time", "count"]
+required = ["applicationID", "instanceID", "application.typeID", "time", "count"]
 
 
 [[endpoint]]
 uri = "/application/timer"
+title = "Application Timer"
+description = "application timers."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "applicationTimerPut"
 required = ["applicationID", "instanceID", "sourceID", "time", "average", "count", "fifty", "ninety"]
 
 
 [[endpoint]]
 uri = "/field/metric"
+title = "Field Metric"
+description = "field metrics."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldMetricProto"
 accept = "application/x-protobuf"
-required = ["deviceID", "typeID"]
+required = ["deviceID", "field.typeID"]
 optional = ["resolution"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldMetricSvg"
 accept = "image/svg+xml"
 default = true
-required = ["deviceID", "typeID"]
+required = ["deviceID", "field.typeID"]
 optional = ["plot", "resolution"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldMetricCsv"
 accept = "text/csv"
-required = ["deviceID", "typeID"]
+required = ["deviceID", "field.typeID"]
 optional = ["resolution"]
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "fieldMetricPut"
-required = ["deviceID", "typeID", "time", "value"]
+required = ["deviceID", "field.typeID", "time", "field.value"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "fieldMetricDelete"
-required = ["deviceID", "typeID"]
+required = ["deviceID", "field.typeID"]
 
 
 [[endpoint]]
 uri = "/field/model"
+title = "Field Model"
+description = "models for field devices."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "fieldModelPut"
 required = ["modelID"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "fieldModelDelete"
 required = ["modelID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldModelProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/field/device"
+title = "Field Device"
+description = "field devices."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "fieldDevicePut"
 required = ["deviceID", "modelID", "latitude", "longitude"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "fieldDeviceDelete"
 required = ["deviceID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldDeviceProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/field/type"
+title = "Field Type"
+description = "field metric types."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldTypeProto"
 accept = "application/x-protobuf"
 
 [[endpoint]]
 uri = "/field/metric/summary"
+title = "Field Metric Summary"
+description = "Field metric summaries."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldLatestProto"
 accept = "application/x-protobuf"
-optional = ["typeID"]
+optional = ["field.typeID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldLatestSvg"
 accept = "image/svg+xml"
-required = ["bbox", "width", "typeID"]
+required = ["bbox", "width", "field.typeID"]
 default = true
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldLatestGeoJSON"
 accept = "application/vnd.geo+json"
-required = ["typeID"]
+required = ["field.typeID"]
 
 
 [[endpoint]]
 uri = "/field/metric/threshold"
+title = "Field Metric Threshold"
+description = "thresholds for field metrics."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "fieldThresholdPut"
-required = ["deviceID", "typeID", "lower", "upper"]
+required = ["deviceID", "field.typeID", "lower", "upper"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "fieldThresholdDelete"
-required = ["deviceID", "typeID"]
+required = ["deviceID", "field.typeID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldThresholdProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/field/metric/tag"
+title = "Field Metric Tag"
+description = "tags for field metrics."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "fieldMetricTagPut"
-required = ["deviceID", "typeID", "tag"]
+required = ["deviceID", "field.typeID", "tag"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "fieldMetricTagDelete"
-required = ["deviceID", "typeID", "tag"]
+required = ["deviceID", "field.typeID", "tag"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldMetricTagProto"
 accept = "application/x-protobuf"
-optional = ["deviceID", "typeID"]
+optional = ["deviceID", "field.typeID"]
 
 
 [[endpoint]]
 uri = "/field/state"
+title = "Field State"
+description = "state for field devices."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "fieldStatePut"
-required = ["deviceID", "typeID", "time", "value"]
+required = ["deviceID", "field.typeID", "time", "state.value"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "fieldStateDelete"
-required = ["deviceID", "typeID"]
+required = ["deviceID", "field.typeID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldStateProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/field/state/tag"
+title = "Field State Tag"
+description = "tags can be added to field state."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "fieldStateTagPut"
-required = ["deviceID", "typeID", "tag"]
+required = ["deviceID", "field.typeID", "tag"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "fieldStateTagDelete"
-required = ["deviceID", "typeID", "tag"]
+required = ["deviceID", "field.typeID", "tag"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "fieldStateTagProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/data/site"
+title = "Data Site"
+description = "sites for data."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "dataSitePut"
 required = ["siteID", "latitude", "longitude"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "dataSiteDelete"
 required = ["siteID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataSiteProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/data/type"
+title = "Data Type"
+description = "types for data."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataTypeProto"
 accept = "application/x-protobuf"
 
 
 [[endpoint]]
 uri = "/data/latency"
+title = "Data Latency"
+description = "latency for data."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "dataLatencyPut"
-required = ["siteID", "typeID", "time", "mean"]
+required = ["siteID", "field.typeID", "time", "mean"]
 optional = ["min", "max", "fifty", "ninety"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "dataLatencyDelete"
-required = ["siteID", "typeID"]
+required = ["siteID", "field.typeID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataLatencySvg"
 accept = "image/svg+xml"
-required = ["siteID", "typeID"]
+required = ["siteID", "field.typeID"]
 optional = ["plot", "resolution", "yrange"]
 default = true
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataLatencyProto"
 accept = "application/x-protobuf"
-required = ["siteID", "typeID"]
+required = ["siteID", "field.typeID"]
 optional = ["resolution"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataLatencyCsv"
 accept = "text/csv"
-required = ["siteID", "typeID"]
+required = ["siteID", "field.typeID"]
 optional = ["resolution"]
 
 
 [[endpoint]]
 uri = "/data/latency/summary"
+title = "Data Latency Summary"
+description = "summary for data latency."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataLatencySummarySvg"
 accept = "image/svg+xml"
-required = ["bbox", "width", "typeID"]
+required = ["bbox", "width", "field.typeID"]
 default = true
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataLatencySummaryProto"
 accept = "application/x-protobuf"
-optional = ["typeID"]
+optional = ["field.typeID"]
 
 
 [[endpoint]]
 uri = "/data/latency/tag"
+title = "Data Latency Tag"
+description = "tag data latency metrics."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "dataLatencyTagPut"
-required = ["siteID", "typeID", "tag"]
+required = ["siteID", "field.typeID", "tag"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "dataLatencyTagDelete"
-required = ["siteID", "typeID", "tag"]
+required = ["siteID", "field.typeID", "tag"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataLatencyTagProto"
 accept = "application/x-protobuf"
-optional = ["siteID", "typeID"]
+optional = ["siteID", "field.typeID"]
 
 
 [[endpoint]]
 uri = "/data/latency/threshold"
+title = "Data Latency Threshold"
+description = "set thresholds on data latency."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "dataLatencyThresholdPut"
-required = ["siteID", "typeID", "lower", "upper"]
+required = ["siteID", "field.typeID", "lower", "upper"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "dataLatencyThresholdDelete"
-required = ["siteID", "typeID"]
+required = ["siteID", "field.typeID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataLatencyThresholdProto"
 accept = "application/x-protobuf"
-optional = ["typeID", "siteID"]
+optional = ["field.typeID", "siteID"]
 
 
 [[endpoint]]
 uri = "/data/completeness"
+title = "Data Completeness"
+description = "completeness for data."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "dataCompletenessPut"
-required = ["siteID", "typeID", "time", "count"]
+required = ["siteID", "field.typeID", "time", "count"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "dataCompletenessDelete"
-required = ["siteID", "typeID"]
+required = ["siteID", "field.typeID"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataCompletenessSvg"
 accept = "image/svg+xml"
 default = true
-required = ["typeID", "siteID"]
+required = ["field.typeID", "siteID"]
 optional = ["plot", "resolution", "yrange"]
 
 
 [[endpoint]]
 uri = "/data/completeness/summary"
+title = "Data Completeness Summary"
+description = "summary of data completeness."
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataCompletenessSummarySvg"
 accept = "image/svg+xml"
 default = true
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataCompletenessSummaryProto"
 accept = "application/x-protobuf"
-optional = ["typeID"]
+optional = ["field.typeID"]
 
 
 [[endpoint]]
 uri = "/data/completeness/tag"
+title = "Data Completeness Tag"
+description = "tag data completeness metrics."
 
-[endpoint.put]
+[[endpoint.request]]
+method = "PUT"
 function = "dataCompletenessTagPut"
-required = ["siteID", "typeID", "tag"]
+required = ["siteID", "field.typeID", "tag"]
 
-[endpoint.delete]
+[[endpoint.request]]
+method = "DELETE"
 function = "dataCompletenessTagDelete"
-required = ["siteID", "typeID", "tag"]
+required = ["siteID", "field.typeID", "tag"]
 
-[[endpoint.get]]
+[[endpoint.request]]
+method = "GET"
 function = "dataCompletenessTagProto"
 accept = "application/x-protobuf"


### PR DESCRIPTION
* Adds query parameter definitions to weft.toml (and updates the format)
* Creates api-docs
* Updates the auto generated handlers. Unfortunately this is messy as I've improved the sorting in weftgenapi.
* some of the wording the the docs could be improved but it's a start at least.

Needs the (not yet merged) latest version of weftgenapi for generation tasks. https://github.com/GeoNet/weft/pull/10

@junghao and @bpeng - you might be interested also?
 
