### PR TITLE
Plotting app 'timers' as points instead of lines, as the SVGs do

### DIFF
--- a/mtr-ui/assets/tmpl/app_plot.html
+++ b/mtr-ui/assets/tmpl/app_plot.html
@@ -33,7 +33,7 @@
                     pointSize: 2,
                     rollPeriod: 1,
                     showRoller: true,
-                    strokeWidth: 2,
+                    strokeWidth: 0.0, // draw points but not lines connecting them
                 };
                 showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=timers",
                             {{urlquery .Resolution}},
@@ -84,7 +84,7 @@
                     pointSize: 2,
                     rollPeriod: 1,
                     showRoller: true,
-                    strokeWidth: 0.0, // draw points but not lines connecting them
+                    strokeWidth: 2,
                 };
                 showGraph("/p/app/metric?applicationID={{urlquery .ApplicationID}}&group=objects",
                             {{urlquery .Resolution}},


### PR DESCRIPTION
Small bugfix.  Plotting the "timers" plot as points instead of connected lines, to match what is done in the SVG plot.