### PR TITLE
Added a timeRange param for all CSV endpoints

### DIFF
--- a/mtr-api/app_metric_test.go
+++ b/mtr-api/app_metric_test.go
@@ -7,6 +7,7 @@ import (
 	wt "github.com/GeoNet/weft/wefttest"
 	"io"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strconv"
 	"strings"
@@ -441,4 +442,48 @@ func TestAppMetricObjectsCsv(t *testing.T) {
 	}
 
 	compareCsvData(b, expectedRoutineSubset, t)
+}
+
+func TestParseTimeRange(t *testing.T) {
+	// both params are unspecified
+	var tr []time.Time
+	var err error
+	if tr, err = parseTimeRange(url.Values{"startDate": nil, "endDate": nil}); err != nil {
+		t.Error(err)
+	}
+
+	if tr != nil {
+		t.Error("timeRange was not nil")
+	}
+
+	t0 := time.Now().Add(time.Second * -10).UTC().Truncate(time.Second)
+	t1 := time.Now().Add(time.Second * -5).UTC().Truncate(time.Second)
+
+	// Test a valid time range
+	if tr, err = parseTimeRange(url.Values{"startDate": {t0.Format(time.RFC3339)}, "endDate": {t1.Format(time.RFC3339)}}); err != nil {
+		t.Error(err)
+	}
+
+	if tr[0] != t0 && tr[1] != t1 {
+		t.Errorf("timeRange time values incorrect, expected: %s-%s but observed %s-%s", t0, t1, tr[0], tr[1])
+	}
+
+	// no startDate but an endDate should use the default startDate
+	if tr, err = parseTimeRange(url.Values{"endDate": {t1.Format(time.RFC3339)}, "resolution": {"minute"}}); err != nil {
+		t.Error(err)
+	}
+
+	newT0 := t1.Add(time.Hour * -12)
+	if tr[0] != newT0 || tr[1] != t1 {
+		t.Errorf("timeRange time values incorrect, \nexpected: \n%s - %s \nobserved: \n%s - %s", newT0, t1, tr[0], tr[1])
+	}
+
+	// a startDate but no endDate should make endDate time.Now()
+	if tr, err = parseTimeRange(url.Values{"startDate": {t0.Format(time.RFC3339)}}); err != nil {
+		t.Error(err)
+	}
+
+	if tr[0] != t0 && tr[1] != time.Now().UTC() {
+		t.Errorf("timeRange time values incorrect, \nexpected: \n%s - %s \nobserved: \n%s - %s", t0, t1, tr[0], tr[1])
+	}
 }

--- a/mtr-api/app_metric_test.go
+++ b/mtr-api/app_metric_test.go
@@ -7,6 +7,8 @@ import (
 	wt "github.com/GeoNet/weft/wefttest"
 	"io"
 	"net/http"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +20,14 @@ func addData(r wt.Request, t *testing.T) {
 	}
 }
 
+// loc returns a string representing the line of code 2 functions calls back.
+func loc() (loc string) {
+	_, _, l, _ := runtime.Caller(2)
+	return "L" + strconv.Itoa(l)
+}
+
 func compareCsvData(b []byte, expected [][]string, t *testing.T) {
+	l := loc()
 	// for all lines past 0 parse and check values.
 	c := csv.NewReader(strings.NewReader(string(b)))
 	observed, err := c.ReadAll()
@@ -27,11 +36,11 @@ func compareCsvData(b []byte, expected [][]string, t *testing.T) {
 	}
 
 	if len(observed) == 0 {
-		t.Errorf("CSV file is empty")
+		t.Errorf("%s CSV file is empty", l)
 	}
 
 	if len(observed) != len(expected) {
-		t.Errorf("Number of lines in observed differs from expected %d %d", len(observed), len(expected))
+		t.Errorf("%s Number of lines in observed differs from expected %d %d", l, len(observed), len(expected))
 	}
 
 	for i, record := range observed {
@@ -40,13 +49,13 @@ func compareCsvData(b []byte, expected [][]string, t *testing.T) {
 		}
 
 		if len(record) != len(expected[i]) {
-			t.Errorf("length of record %d not equal to expected %d", len(record), len(expected))
+			t.Errorf("%s length of record %d not equal to expected %d", l, len(record), len(expected))
 		}
 
 		for f, field := range record {
 			if field != expected[i][f] {
-				t.Errorf("expected '%s' but observed: '%s' (field %d)",
-					strings.Join(expected[i], ", "), strings.Join(observed[i], ", "), f)
+				t.Errorf("%s expected '%s' but observed: '%s' (field %d)",
+					l, strings.Join(expected[i], ", "), strings.Join(observed[i], ", "), f)
 			}
 		}
 	}
@@ -76,13 +85,13 @@ func TestAppMetricCounterCsv(t *testing.T) {
 
 	// Testing the "counter" group
 
-	now := time.Now().UTC()
+	t0 := time.Now().UTC().Add(time.Second * -50)
 	testCounterData := []testPoint{
-		{typeID: http.StatusOK, count: 1.0, time: now},
-		{typeID: http.StatusBadRequest, count: 2.0, time: now}, // add a different typeID at the same time as previous typeID
-		{typeID: http.StatusNotFound, count: 1.0, time: now.Add(time.Second)},
-		{typeID: http.StatusBadRequest, count: 2.0, time: now.Add(time.Second * 2)},
-		{typeID: http.StatusInternalServerError, count: 3.0, time: now.Add(time.Second * 5)},
+		{typeID: http.StatusOK, count: 1.0, time: t0},
+		{typeID: http.StatusBadRequest, count: 2.0, time: t0}, // add a different typeID at the same time as previous typeID
+		{typeID: http.StatusNotFound, count: 1.0, time: t0.Add(time.Second)},
+		{typeID: http.StatusBadRequest, count: 2.0, time: t0.Add(time.Second * 2)},
+		{typeID: http.StatusInternalServerError, count: 3.0, time: t0.Add(time.Second * 5)},
 	}
 
 	// the expected CSV data, ignoring the header fields on the first line
@@ -108,6 +117,22 @@ func TestAppMetricCounterCsv(t *testing.T) {
 		t.Error(err)
 	}
 	compareCsvData(b, expectedVals, t)
+
+	// test with time range specified
+	expectedSubset := [][]string{
+		{""}, // header line, ignored in test.  Should be time, statusOK, statusBadRequest
+		{testCounterData[0].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", testCounterData[0].count), fmt.Sprintf("%.2f", testCounterData[1].count)},
+	}
+
+	// time window so we only get the points at t0
+	start := t0.Add(time.Second * -1).Format(time.RFC3339)
+	end := t0.Add(time.Millisecond * 5).Format(time.RFC3339)
+	r = wt.Request{ID: wt.L(), URL: "/app/metric?applicationID=test-app&group=counters&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+	compareCsvData(b, expectedSubset, t)
 }
 
 func TestAppMetricTimerCsv(t *testing.T) {
@@ -135,14 +160,14 @@ func TestAppMetricTimerCsv(t *testing.T) {
 		time    time.Time
 	}
 
-	now := time.Now().UTC()
+	t0 := time.Now().Add(time.Second * -100).UTC()
 	timerTestData := []timerTest{
-		{appId: "func-name", count: 1, average: 30, fifty: 73, ninety: 81, time: now},
-		{appId: "func-name2", count: 3, average: 32, fifty: 57, ninety: 59, time: now}, // same time as above but different appId
-		{appId: "func-name3", count: 6, average: 31, fifty: 76, ninety: 82, time: now},
-		{appId: "func-name", count: 4, average: 36, fifty: 73, ninety: 78, time: now.Add(time.Second * 2)},
-		{appId: "func-name", count: 2, average: 33, fifty: 76, ninety: 93, time: now.Add(time.Second * 3)},
-		{appId: "func-name", count: 9, average: 38, fifty: 73, ninety: 91, time: now.Add(time.Second * 7)},
+		{appId: "func-name", count: 1, average: 30, fifty: 73, ninety: 81, time: t0},
+		{appId: "func-name2", count: 3, average: 32, fifty: 57, ninety: 59, time: t0}, // same time as above but different appId
+		{appId: "func-name3", count: 6, average: 31, fifty: 76, ninety: 82, time: t0},
+		{appId: "func-name", count: 4, average: 36, fifty: 73, ninety: 78, time: t0.Add(time.Second * 2)},
+		{appId: "func-name", count: 2, average: 33, fifty: 76, ninety: 93, time: t0.Add(time.Second * 3)},
+		{appId: "func-name", count: 9, average: 38, fifty: 73, ninety: 91, time: t0.Add(time.Second * 7)},
 	}
 
 	// the expected CSV data, ignoring the header fields on the first line
@@ -172,7 +197,24 @@ func TestAppMetricTimerCsv(t *testing.T) {
 	}
 	compareCsvData(b, expectedTimerVals, t)
 
-	// do same test with sourceID specified since it uses another SQL query and outputs different results
+	// same test with time range
+	start := timerTestData[3].time.Add(time.Millisecond * -100).Format(time.RFC3339)
+	end := timerTestData[3].time.Add(time.Millisecond * 100).Format(time.RFC3339)
+	r = wt.Request{ID: wt.L(), URL: "/app/metric?applicationID=test-app&group=timers&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
+
+	expectedTimerSubset := [][]string{
+		{""}, // header line, ignored in test.  Should be: time, func-name.
+		{timerTestData[3].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", timerTestData[3].ninety)},
+	}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
+	//fmt.Println(string(b), start, end, "subset time", timerTestData[3].time)
+	compareCsvData(b, expectedTimerSubset, t)
+
+	// do same test with sourceID specified since it uses another SQL query and outputs different results (average, fifty, ninety for the specified applicationID)
 	r = wt.Request{ID: wt.L(), URL: "/app/metric?applicationID=test-app&group=timers&sourceID=func-name&resolution=full", Method: "GET", Accept: "text/csv"}
 
 	if b, err = r.Do(testServer.URL); err != nil {
@@ -199,6 +241,22 @@ func TestAppMetricTimerCsv(t *testing.T) {
 			fmt.Sprintf("%.2f", timerTestData[5].ninety)},
 	}
 	compareCsvData(b, expectedTimerSrcVals, t)
+
+	// similar test but with a time range
+	r = wt.Request{ID: wt.L(), URL: "/app/metric?applicationID=test-app&group=timers&sourceID=func-name&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
+	expectedTimerSrcSubset := [][]string{
+		{""}, // header line, ignored in test.  Should be: time, func-name.
+		{timerTestData[3].time.Format(DYGRAPH_TIME_FORMAT),
+			fmt.Sprintf("%.2f", timerTestData[3].average),
+			fmt.Sprintf("%.2f", timerTestData[3].fifty),
+			fmt.Sprintf("%.2f", timerTestData[3].ninety)},
+	}
+	compareCsvData(b, expectedTimerSrcSubset, t)
 
 }
 
@@ -227,13 +285,13 @@ func TestAppMetricMemoryCsv(t *testing.T) {
 
 	//"/application/metric?applicationID=test-app&instanceID=test-instance&typeID=1000&value=10000&time=2015-05-14T21:40:30Z"
 	//applicationID=test-app   instanceID=test-instance    typeID=1000    value=10000    time=2015-05-14T21:40:30Z"
-	now := time.Now().UTC()
+	t0 := time.Now().Add(time.Second * -10).UTC()
 	memTestData := []memoryTest{
-		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 10, time: now},
-		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 9, time: now.Add(time.Second)},
-		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 8, time: now.Add(time.Second * 2)},
-		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 7, time: now.Add(time.Second * 3)},
-		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 6, time: now.Add(time.Second * 6)},
+		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 10, time: t0},
+		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 9, time: t0.Add(time.Second)},
+		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 8, time: t0.Add(time.Second * 2)},
+		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 7, time: t0.Add(time.Second * 3)},
+		{appId: "test-app", instanceId: "test-instance", typeId: 1000, value: 6, time: t0.Add(time.Second * 6)},
 	}
 
 	// the expected CSV data, ignoring the header fields on the first line
@@ -264,6 +322,22 @@ func TestAppMetricMemoryCsv(t *testing.T) {
 	}
 
 	compareCsvData(b, expectedMemVals, t)
+
+	// test with time range
+	start := memTestData[3].time.Add(time.Millisecond * -100).UTC().Format(time.RFC3339)
+	end := memTestData[3].time.Add(time.Millisecond * 100).UTC().Format(time.RFC3339)
+	r = wt.Request{ID: wt.L(), URL: "/app/metric?applicationID=test-app&group=memory&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
+	expectedMemSubset := [][]string{
+		{""}, // header line, ignored in test.
+		{memTestData[3].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", memTestData[3].value)},
+	}
+	compareCsvData(b, expectedMemSubset, t)
+
 }
 
 func TestAppMetricObjectsCsv(t *testing.T) {
@@ -282,7 +356,7 @@ func TestAppMetricObjectsCsv(t *testing.T) {
 		Method:   "PUT",
 	}
 
-	type memoryTest struct {
+	type objectTest struct {
 		appId, instanceId string
 		typeId            int
 		value             float64
@@ -290,15 +364,15 @@ func TestAppMetricObjectsCsv(t *testing.T) {
 	}
 
 	// handling objects and routines in the same test since it's the same method being exercised
-	now := time.Now().UTC()
-	objTestData := []memoryTest{
-		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapObjects), value: 8, time: now.Add(time.Second)},
-		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapObjects), value: 12, time: now.Add(time.Second * 2)},
-		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.Routines), value: 1, time: now.Add(time.Second * 3)},
-		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.Routines), value: 3, time: now.Add(time.Second * 4)},
-		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemSys), value: 10, time: now.Add(time.Second * 5)},
-		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapAlloc), value: 9, time: now.Add(time.Second * 6)},
-		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapSys), value: 7, time: now.Add(time.Second * 7)},
+	t0 := time.Now().Add(time.Second * -10).UTC()
+	objTestData := []objectTest{
+		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapObjects), value: 8, time: t0.Add(time.Second)},
+		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapObjects), value: 12, time: t0.Add(time.Second * 2)},
+		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.Routines), value: 1, time: t0.Add(time.Second * 3)},
+		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.Routines), value: 3, time: t0.Add(time.Second * 4)},
+		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemSys), value: 10, time: t0.Add(time.Second * 5)},
+		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapAlloc), value: 9, time: t0.Add(time.Second * 6)},
+		{appId: "test-app", instanceId: "test-instance", typeId: int(internal.MemHeapSys), value: 7, time: t0.Add(time.Second * 7)},
 	}
 
 	// the expected CSV data, ignoring the header fields on the first line
@@ -349,4 +423,20 @@ func TestAppMetricObjectsCsv(t *testing.T) {
 	if b, err = r.Do(testServer.URL); err != nil {
 		t.Error(err)
 	}
+
+	// Test again with time range
+	start := objTestData[3].time.Add(time.Millisecond * -100).UTC().Format(time.RFC3339)
+	end := objTestData[3].time.Add(time.Millisecond * 100).UTC().Format(time.RFC3339)
+	r = wt.Request{ID: wt.L(), URL: "/app/metric?applicationID=test-app&group=routines&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
+	expectedRoutineSubset := [][]string{
+		{""}, // header line, ignored in test.
+		{objTestData[3].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", objTestData[3].value)},
+	}
+
+	compareCsvData(b, expectedRoutineSubset, t)
 }

--- a/mtr-api/assets/api-docs/index.html
+++ b/mtr-api/assets/api-docs/index.html
@@ -273,7 +273,7 @@
 
 	
 	<h4>Optional Query Parameters:</h4>
-	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>sourceID</dt><dd>[string] source identifier for the metrics, often the function name.</dd></dl>
+	<dl class="dl-horizontal"><dt>endDate</dt><dd>[string] RFC3339 formatted date for the end date of a range window</dd><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>sourceID</dt><dd>[string] source identifier for the metrics, often the function name.</dd><dt>startDate</dt><dd>[string] RFC3339 formatted date for the start date of a range window</dd></dl>
 	
 
 	
@@ -751,7 +751,7 @@
 
 	
 	<h4>Optional Query Parameters:</h4>
-	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd></dl>
+	<dl class="dl-horizontal"><dt>endDate</dt><dd>[string] RFC3339 formatted date for the end date of a range window</dd><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>startDate</dt><dd>[string] RFC3339 formatted date for the start date of a range window</dd></dl>
 	
 
 	
@@ -1323,7 +1323,7 @@
 
 	
 	<h4>Optional Query Parameters:</h4>
-	<dl class="dl-horizontal"><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd></dl>
+	<dl class="dl-horizontal"><dt>endDate</dt><dd>[string] RFC3339 formatted date for the end date of a range window</dd><dt>resolution</dt><dd>[string] resolution for the plot e.g., five_minutes</dd><dt>startDate</dt><dd>[string] RFC3339 formatted date for the start date of a range window</dd></dl>
 	
 
 	

--- a/mtr-api/data_latency.go
+++ b/mtr-api/data_latency.go
@@ -293,7 +293,12 @@ func dataLatencyProto(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Res
 		return weft.InternalServerError(err)
 	}
 
-	rows, err := queryLatencyRows(sitePK, typePK, resolution, nil)
+	var timeRange []time.Time
+	if timeRange, err = defaultTimeRange(resolution); err != nil {
+		weft.InternalServerError(err)
+	}
+
+	rows, err := queryLatencyRows(sitePK, typePK, resolution, timeRange)
 	if err != nil {
 		return weft.InternalServerError(err)
 	}
@@ -404,7 +409,12 @@ func dataLatencyPlot(siteID, typeID, resolution string, plotter ts.SVGPlot, b *b
 		return weft.InternalServerError(err)
 	}
 
-	rows, err = queryLatencyRows(sitePK, typePK, resolution, nil)
+	var timeRange []time.Time
+	if timeRange, err = defaultTimeRange(resolution); err != nil {
+		weft.InternalServerError(err)
+	}
+
+	rows, err = queryLatencyRows(sitePK, typePK, resolution, timeRange)
 	defer rows.Close()
 
 	pts := make(map[internal.ID]([]ts.Point))
@@ -517,12 +527,6 @@ func dataLatencySpark(siteID, typeID string, b *bytes.Buffer) *weft.Result {
 func queryLatencyRows(sitePK, typePK int, resolution string, timeRange []time.Time) (*sql.Rows, error) {
 	var err error
 	var rows *sql.Rows
-
-	if timeRange == nil {
-		if timeRange, err = defaultTimeRange(resolution); err != nil {
-			weft.InternalServerError(err)
-		}
-	}
 
 	switch resolution {
 	case "minute":

--- a/mtr-api/data_latency.go
+++ b/mtr-api/data_latency.go
@@ -519,7 +519,7 @@ func queryLatencyRows(sitePK, typePK int, resolution string, timeRange []time.Ti
 	var rows *sql.Rows
 
 	if timeRange == nil {
-		if timeRange, err = getTimeRange(resolution); err != nil {
+		if timeRange, err = defaultTimeRange(resolution); err != nil {
 			weft.InternalServerError(err)
 		}
 	}

--- a/mtr-api/data_latency_test.go
+++ b/mtr-api/data_latency_test.go
@@ -29,7 +29,8 @@ func TestDataLatencyCsv(t *testing.T) {
 		mean, fifty, ninety float32
 	}
 
-	t0 := time.Now().Add(time.Second * -75).UTC()
+	utcNow := time.Now().UTC().Truncate(time.Second)
+	t0 := utcNow.Add(time.Second * -10)
 	latencyTestData := []latencyTest{
 		{time: t0, mean: 20, fifty: 30, ninety: 40},
 		// Can only have one value due to rate_limit.
@@ -71,8 +72,8 @@ func TestDataLatencyCsv(t *testing.T) {
 	}
 
 	// Test with a time range
-	start := latencyTestData[0].time.Add(time.Millisecond * -100).UTC().Format(time.RFC3339)
-	end := latencyTestData[0].time.Add(time.Millisecond * 100).UTC().Format(time.RFC3339)
+	start := latencyTestData[0].time.Add(time.Second * -1).UTC().Format(time.RFC3339)
+	end := latencyTestData[0].time.Add(time.Second).UTC().Format(time.RFC3339)
 	r = wt.Request{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
 
 	if b, err = r.Do(testServer.URL); err != nil {

--- a/mtr-api/data_latency_test.go
+++ b/mtr-api/data_latency_test.go
@@ -24,30 +24,35 @@ func TestDataLatencyCsv(t *testing.T) {
 	}
 	var err error
 
-	expectedVals := [][]string{}
-	expectedVals = append(expectedVals, []string{""}) // header line, not checked
+	type latencyTest struct {
+		time                time.Time
+		mean, fifty, ninety float32
+	}
 
-	// Load some latency metrics, don't need many
-	now := time.Now().UTC()
-	v := 140
-	for i := -100; i < 0; i += 1 {
-		v += i
+	t0 := time.Now().Add(time.Second * -75).UTC()
+	latencyTestData := []latencyTest{
+		{time: t0, mean: 20, fifty: 30, ninety: 40},
+		// Can only have one value due to rate_limit.
+		// TODO: make the rate_limit value configurable so we can test properly
+		//{time: t0.Add(time.Second), mean: 21, fifty:31, ninety: 41},
+		//{time: t0.Add(time.Second * 2), mean: 22, fifty:32, ninety: 42},
+		//{time: t0.Add(time.Second * 3), mean: 23, fifty:33, ninety: 43},
+	}
 
-		ptTime := now.Add(time.Duration(i) * time.Minute)
+	expectedVals := [][]string{
+		{""}, // header line, ignored in test.
+		{latencyTestData[0].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", latencyTestData[0].mean), fmt.Sprintf("%.2f", latencyTestData[0].fifty), fmt.Sprintf("%.2f", latencyTestData[0].ninety)},
+		//{latencyTestData[1].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", latencyTestData[1].mean), fmt.Sprintf("%.2f", latencyTestData[1].fifty), fmt.Sprintf("%.2f", latencyTestData[1].ninety)},
+		//{latencyTestData[2].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", latencyTestData[2].mean), fmt.Sprintf("%.2f", latencyTestData[2].fifty), fmt.Sprintf("%.2f", latencyTestData[2].ninety)},
+		//{latencyTestData[3].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", latencyTestData[3].mean), fmt.Sprintf("%.2f", latencyTestData[3].fifty), fmt.Sprintf("%.2f", latencyTestData[3].ninety)},
+	}
+
+	// Add metrics
+	for _, lt := range latencyTestData {
 		r.URL = fmt.Sprintf("/data/latency?siteID=TAUP&typeID=latency.strong&time=%s&mean=%d&fifty=%d&ninety=%d",
-			ptTime.Format(time.RFC3339), v, v*10, v*11)
+			lt.time.Format(time.RFC3339), int(lt.mean), int(lt.fifty), int(lt.ninety))
 
-		// expected values
-		record := []string{ptTime.Format(DYGRAPH_TIME_FORMAT),
-			fmt.Sprintf("%.2f", float32(v)),
-			fmt.Sprintf("%.2f", float32(v*10)),
-			fmt.Sprintf("%.2f", float32(v*11)),
-		}
-		expectedVals = append(expectedVals, record)
-
-		if _, err = r.Do(testServer.URL); err != nil {
-			t.Error(err)
-		}
+		addData(r, t)
 	}
 
 	r = wt.Request{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&resolution=full", Method: "GET", Accept: "text/csv"}
@@ -56,7 +61,6 @@ func TestDataLatencyCsv(t *testing.T) {
 	if b, err = r.Do(testServer.URL); err != nil {
 		t.Error(err)
 	}
-
 	compareCsvData(b, expectedVals, t)
 
 	// test for invalid siteID condition
@@ -65,4 +69,15 @@ func TestDataLatencyCsv(t *testing.T) {
 	if b, err = r.Do(testServer.URL); err != nil {
 		t.Error(err)
 	}
+
+	// Test with a time range
+	start := latencyTestData[0].time.Add(time.Millisecond * -100).UTC().Format(time.RFC3339)
+	end := latencyTestData[0].time.Add(time.Millisecond * 100).UTC().Format(time.RFC3339)
+	r = wt.Request{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
+	compareCsvData(b, expectedVals, t)
 }

--- a/mtr-api/field_metric.go
+++ b/mtr-api/field_metric.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"github.com/GeoNet/mtr/mtrpb"
 	"github.com/GeoNet/mtr/ts"
@@ -166,6 +167,11 @@ func fieldMetricCsv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resul
 	typeID := v.Get("typeID")
 	var err error
 
+	var timeRange []time.Time
+	if timeRange, err = parseTimeRange(v); err != nil {
+		return weft.InternalServerError(err)
+	}
+
 	var devicePK int
 	if err = dbR.QueryRow(`SELECT devicePK FROM field.device WHERE deviceID = $1`,
 		deviceID).Scan(&devicePK); err != nil {
@@ -186,7 +192,7 @@ func fieldMetricCsv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resul
 	}
 
 	var rows *sql.Rows
-	rows, err = queryMetricRows(devicePK, typePK, resolution)
+	rows, err = queryMetricRows(devicePK, typePK, resolution, timeRange)
 	if err != nil {
 		return weft.InternalServerError(err)
 	}
@@ -260,7 +266,7 @@ func fieldMetricProto(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Res
 	}
 
 	var rows *sql.Rows
-	rows, err = queryMetricRows(devicePK, typePK, resolution)
+	rows, err = queryMetricRows(devicePK, typePK, resolution, nil)
 	if err != nil {
 		return weft.InternalServerError(err)
 	}
@@ -380,7 +386,7 @@ func (f fieldMetric) plot(deviceID, typeID, resolution string, plotter ts.SVGPlo
 		return weft.BadRequest("invalid resolution")
 	}
 
-	rows, err = queryMetricRows(devicePK, typePK, resolution)
+	rows, err = queryMetricRows(devicePK, typePK, resolution, nil)
 	if err != nil {
 		return weft.InternalServerError(err)
 	}
@@ -466,43 +472,49 @@ func (f fieldMetric) spark(deviceID, typeID string, b *bytes.Buffer) *weft.Resul
 	return &weft.StatusOK
 }
 
-func queryMetricRows(devicePK, typePK int, resolution string) (*sql.Rows, error) {
+func queryMetricRows(devicePK, typePK int, resolution string, timeRange []time.Time) (*sql.Rows, error) {
 	var err error
 	var rows *sql.Rows
+
+	if timeRange == nil {
+		if timeRange, err = getTimeRange(resolution); err != nil {
+			weft.InternalServerError(err)
+		}
+	}
 
 	switch resolution {
 	case "minute":
 		rows, err = dbR.Query(`SELECT date_trunc('`+resolution+`',time) as t, avg(value) FROM field.metric WHERE
 		devicePK = $1 AND typePK = $2
-		AND time > now() - interval '12 hours'
+		AND time >= $3 AND time <= $4
 		GROUP BY date_trunc('`+resolution+`',time)
 		ORDER BY t ASC`,
-			devicePK, typePK)
+			devicePK, typePK, timeRange[0], timeRange[1])
 	case "five_minutes":
 		rows, err = dbR.Query(`SELECT date_trunc('hour', time) + extract(minute from time)::int / 5 * interval '5 min' as t,
 		 avg(value) FROM field.metric WHERE
 		devicePK = $1 AND typePK = $2
-		AND time > now() - interval '2 days'
+		AND time >= $3 AND time <= $4
 		GROUP BY date_trunc('hour', time) + extract(minute from time)::int / 5 * interval '5 min'
 		ORDER BY t ASC`,
-			devicePK, typePK)
+			devicePK, typePK, timeRange[0], timeRange[1])
 	case "hour":
 		rows, err = dbR.Query(`SELECT date_trunc('`+resolution+`',time) as t, avg(value) FROM field.metric WHERE
 		devicePK = $1 AND typePK = $2
-		AND time > now() - interval '28 days'
+		AND time >= $3 AND time <= $4
 		GROUP BY date_trunc('`+resolution+`',time)
 		ORDER BY t ASC`,
-			devicePK, typePK)
+			devicePK, typePK, timeRange[0], timeRange[1])
 	case "full":
 		rows, err = dbR.Query(`SELECT time, value
 		FROM field.metric
 		WHERE devicePK = $1
 		AND typePK = $2
-		AND time > now() - interval '40 days'
+		AND time >= $3 AND time <= $4
 		ORDER BY time ASC`,
-			devicePK, typePK)
+			devicePK, typePK, timeRange[0], timeRange[1])
 	default:
-		return nil, fmt.Errorf("invalid resolution")
+		return nil, errors.New("invalid resolution")
 	}
 	if err != nil {
 		return nil, err

--- a/mtr-api/field_metric.go
+++ b/mtr-api/field_metric.go
@@ -477,7 +477,7 @@ func queryMetricRows(devicePK, typePK int, resolution string, timeRange []time.T
 	var rows *sql.Rows
 
 	if timeRange == nil {
-		if timeRange, err = getTimeRange(resolution); err != nil {
+		if timeRange, err = defaultTimeRange(resolution); err != nil {
 			weft.InternalServerError(err)
 		}
 	}

--- a/mtr-api/field_metric_test.go
+++ b/mtr-api/field_metric_test.go
@@ -31,9 +31,10 @@ func TestFieldMetricCsv(t *testing.T) {
 
 	// Testing the "counter" group
 
-	now := time.Now().Add(time.Second * -50).UTC()
+	utcNow := time.Now().UTC().Truncate(time.Second)
+	t0 := utcNow.Add(time.Second * -10)
 	testData := []testPoint{
-		{time: now, value: 10000.0}, // can only use one point due to rate limiting in put method
+		{time: t0, value: 10000.0}, // can only use one point due to rate limiting in put method
 	}
 
 	// the expected CSV data, ignoring the header fields on the first line
@@ -65,8 +66,8 @@ func TestFieldMetricCsv(t *testing.T) {
 	}
 
 	// test with a time range, only one point so not much we can do
-	start := testData[0].time.Add(time.Millisecond * -100).UTC().Format(time.RFC3339)
-	end := testData[0].time.Add(time.Millisecond * 100).UTC().Format(time.RFC3339)
+	start := testData[0].time.Add(time.Second * -1).UTC().Format(time.RFC3339)
+	end := testData[0].time.Add(time.Second).UTC().Format(time.RFC3339)
 	r = wt.Request{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
 
 	if b, err = r.Do(testServer.URL); err != nil {

--- a/mtr-api/field_metric_test.go
+++ b/mtr-api/field_metric_test.go
@@ -31,7 +31,7 @@ func TestFieldMetricCsv(t *testing.T) {
 
 	// Testing the "counter" group
 
-	now := time.Now().UTC()
+	now := time.Now().Add(time.Second * -50).UTC()
 	testData := []testPoint{
 		{time: now, value: 10000.0}, // can only use one point due to rate limiting in put method
 	}
@@ -63,4 +63,19 @@ func TestFieldMetricCsv(t *testing.T) {
 	if b, err = r.Do(testServer.URL); err != nil {
 		t.Error(err)
 	}
+
+	// test with a time range, only one point so not much we can do
+	start := testData[0].time.Add(time.Millisecond * -100).UTC().Format(time.RFC3339)
+	end := testData[0].time.Add(time.Millisecond * 100).UTC().Format(time.RFC3339)
+	r = wt.Request{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&resolution=full&startDate=" + start + "&endDate=" + end, Method: "GET", Accept: "text/csv"}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
+	expectedSubset := [][]string{
+		{""}, // header line, ignored in test.  Should be time, value
+		{testData[0].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", testData[0].value*scale)},
+	}
+	compareCsvData(b, expectedSubset, t)
 }

--- a/mtr-api/handlers_auto.go
+++ b/mtr-api/handlers_auto.go
@@ -84,7 +84,7 @@ func appmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Res
 			h.Set("Content-Type", "image/svg+xml")
 			return appMetricSvg(r, h, b)
 		case "text/csv":
-			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"resolution", "sourceID"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"applicationID", "group"}, []string{"endDate", "resolution", "sourceID", "startDate"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "text/csv")
@@ -260,7 +260,7 @@ func datalatencyHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.R
 			h.Set("Content-Type", "application/x-protobuf")
 			return dataLatencyProto(r, h, b)
 		case "text/csv":
-			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"resolution"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"endDate", "resolution", "startDate"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "text/csv")
@@ -462,7 +462,7 @@ func fieldmetricHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.R
 			h.Set("Content-Type", "image/svg+xml")
 			return fieldMetricSvg(r, h, b)
 		case "text/csv":
-			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution"}); !res.Ok {
+			if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"endDate", "resolution", "startDate"}); !res.Ok {
 				return res
 			}
 			h.Set("Content-Type", "text/csv")

--- a/mtr-api/weft.toml
+++ b/mtr-api/weft.toml
@@ -34,6 +34,14 @@ type = "int"
 description = "RFC3339 formatted time"
 type = "string"
 
+[query.startDate]
+description = "RFC3339 formatted date for the start date of a range window"
+type = "string"
+
+[query.endDate]
+description = "RFC3339 formatted date for the end date of a range window"
+type = "string"
+
 [query."application.value"]
 id = "value"
 description = "the metric value."
@@ -189,7 +197,7 @@ method = "GET"
 function = "appMetricCsv"
 accept = "text/csv"
 required = ["applicationID", "group"]
-optional = ["sourceID", "resolution"]
+optional = ["sourceID", "resolution", "startDate", "endDate"]
 
 
 [[endpoint]]
@@ -250,7 +258,7 @@ method = "GET"
 function = "fieldMetricCsv"
 accept = "text/csv"
 required = ["deviceID", "field.typeID"]
-optional = ["resolution"]
+optional = ["resolution", "startDate", "endDate"]
 
 [[endpoint.request]]
 method = "PUT"
@@ -493,7 +501,7 @@ method = "GET"
 function = "dataLatencyCsv"
 accept = "text/csv"
 required = ["siteID", "field.typeID"]
-optional = ["resolution"]
+optional = ["resolution", "startDate", "endDate"]
 
 
 [[endpoint]]


### PR DESCRIPTION
Adding an optional startDate and endDate parameter to all CSV endpoints in mtr-api.  This is needed by for progressive loading of data with the interactive graphs (part of GeoNet/mtr#222).

