### PR TITLE
Field metric csv multiple typeids

### DIFF
--- a/mtr-api/app_metric.go
+++ b/mtr-api/app_metric.go
@@ -117,7 +117,7 @@ func appMetricCsv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result 
 	for i, d := range allData {
 		points := d.Series.Points
 		for _, point := range points {
-			if values[point.DateTime] == nil {
+			if _, ok := values[point.DateTime]; ok == false {
 				values[point.DateTime] = map[string]float64{labels[i].Label: point.Value}
 				ts = append(ts, point.DateTime)
 			} else {
@@ -137,7 +137,9 @@ func appMetricCsv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result 
 
 		// CSV headers
 		if i == 0 {
-			w.Write(headers)
+			if err = w.Write(headers); err != nil {
+				return weft.InternalServerError(err)
+			}
 		}
 
 		fields := []string{t.Format(DYGRAPH_TIME_FORMAT)}
@@ -155,7 +157,9 @@ func appMetricCsv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result 
 			}
 		}
 
-		w.Write(fields)
+		if err = w.Write(fields); err != nil {
+			return weft.InternalServerError(err)
+		}
 	}
 
 	w.Flush()

--- a/mtr-api/data_latency.go
+++ b/mtr-api/data_latency.go
@@ -226,7 +226,9 @@ func dataLatencyCsv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resul
 
 		// CSV headers
 		if i == 0 {
-			w.Write([]string{"time", "mean", "fifty", "ninety"})
+			if err = w.Write([]string{"time", "mean", "fifty", "ninety"}); err != nil {
+				return weft.InternalServerError(err)
+			}
 		}
 
 		// CSV data
@@ -236,10 +238,13 @@ func dataLatencyCsv(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resul
 		if err != nil {
 			return weft.InternalServerError(err)
 		}
-		w.Write([]string{t.Format(DYGRAPH_TIME_FORMAT),
+
+		if err = w.Write([]string{t.Format(DYGRAPH_TIME_FORMAT),
 			fmt.Sprintf("%.2f", float64(dl.Mean)),
 			fmt.Sprintf("%.2f", float64(dl.Fifty)),
-			fmt.Sprintf("%.2f", float64(dl.Ninety))})
+			fmt.Sprintf("%.2f", float64(dl.Ninety))}); err != nil {
+			return weft.InternalServerError(err)
+		}
 		i++
 	}
 	rows.Close()

--- a/mtr-api/field_metric_test.go
+++ b/mtr-api/field_metric_test.go
@@ -79,4 +79,24 @@ func TestFieldMetricCsv(t *testing.T) {
 		{testData[0].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", testData[0].value*scale)},
 	}
 	compareCsvData(b, expectedSubset, t)
+
+	// test multiple typeIDs in a single call (using voltage twice since we only have a single metric), needed for plotting N different series on one graph.
+	r = wt.Request{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=voltage&typeID=voltage&resolution=full", Method: "GET", Accept: "text/csv"}
+
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
+	expectedOutput := [][]string{
+		{""}, // header line, ignored in test.  Should be time, voltage, voltage
+		{testData[0].time.Format(DYGRAPH_TIME_FORMAT), fmt.Sprintf("%.2f", testData[0].value*scale), fmt.Sprintf("%.2f", testData[0].value*scale)},
+	}
+	compareCsvData(b, expectedOutput, t)
+
+	// an invalid typeID should get a 404
+	r = wt.Request{ID: wt.L(), URL: "/field/metric?deviceID=gps-taupoairport&typeID=notAValidTypeID&resolution=full", Method: "GET", Accept: "text/csv", Status: http.StatusNotFound}
+	if b, err = r.Do(testServer.URL); err != nil {
+		t.Error(err)
+	}
+
 }

--- a/vendor/github.com/GeoNet/weft/handlers.go
+++ b/vendor/github.com/GeoNet/weft/handlers.go
@@ -72,10 +72,9 @@ func MakeHandlerPage(f RequestHandler) http.HandlerFunc {
 		t.Track(name(f) + "." + r.Method)
 		res.Count()
 
-		// log errors and slow 200s
-		if res.Code != http.StatusOK {
-			log.Printf("status: %d serving %s", res.Code, r.RequestURI)
-		} else if t.Taken() > 250 {
+		res.log(r)
+
+		if t.Taken() > 250 {
 			log.Printf("slow: took %d ms serving %s", t.Taken(), r.RequestURI)
 		}
 	}
@@ -113,10 +112,9 @@ func MakeHandlerAPI(f RequestHandler) http.HandlerFunc {
 		t.Track(name(f) + "." + r.Method)
 		res.Count()
 
-		// log errors and slow 200s
-		if res.Code != http.StatusOK {
-			log.Printf("status: %d serving %s", res.Code, r.RequestURI)
-		} else if t.Taken() > 250 {
+		res.log(r)
+
+		if t.Taken() > 250 {
 			log.Printf("slow: took %d ms serving %s", t.Taken(), r.RequestURI)
 		}
 	}

--- a/vendor/github.com/GeoNet/weft/result.go
+++ b/vendor/github.com/GeoNet/weft/result.go
@@ -1,0 +1,14 @@
+// +build !devmode
+
+package weft
+
+import (
+	"log"
+	"net/http"
+)
+
+func (res Result) log(r *http.Request) {
+	if res.Code != http.StatusOK {
+		log.Printf("status: %d serving %s", res.Code, r.RequestURI)
+	}
+}

--- a/vendor/github.com/GeoNet/weft/result_dev.go
+++ b/vendor/github.com/GeoNet/weft/result_dev.go
@@ -1,0 +1,15 @@
+// +build devmode
+
+package weft
+
+import (
+	"log"
+	"net/http"
+)
+
+func (res Result) log(r *http.Request) {
+	log.Printf("status: %d %b serving %s", res.Code, res.Ok, r.RequestURI)
+	if res.Msg != "" {
+		log.Printf("msg: %s", res.Msg)
+	}
+}

--- a/vendor/github.com/GeoNet/weft/weft.go
+++ b/vendor/github.com/GeoNet/weft/weft.go
@@ -1,5 +1,9 @@
 /*
 weft helps with web applications.
+
+There are build tags to give extra log output in devmode e.g.,
+
+go build -tags devmode ...
 */
 package weft
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,8 +21,8 @@
 		},
 		{
 			"path": "github.com/GeoNet/weft",
-			"revision": "53cad5eb6e41d631600d3c5de983108563fcd8ee",
-			"revisionTime": "2016-05-02T16:28:30+12:00"
+			"revision": "13993260f60096e063f93c8b41f93bcdcb50fa04",
+			"revisionTime": "2016-07-25T08:50:42+12:00"
 		},
 		{
 			"checksumSHA1": "qxcW1hstrjlHw/t4qGzigqDudcc=",


### PR DESCRIPTION
Added support for multiple typeIDs when calling the fieldMetricCsv handler.  These are handled by supplying multiple typeID parameters in the URL, eg: "/field/metric?deviceID=gps-taupoairport&typeID=rf.signal&typeID=rf.noise".

I've used an anonymous function so I can use "defer rows.Close()" properly for each SQL query.

I've also added more checks for errors when writing to the CSV file, and updated the vendored version of weft to get access to the "devmode" build tag for better error reporting when testing.

This is the major part of GeoNet/mtr#168.