### PR TITLE
New latency typeID 'latency.files.gnss' and completeness typeID 'comp…

### DIFF
--- a/database/ddl/data-schema.ddl
+++ b/database/ddl/data-schema.ddl
@@ -36,6 +36,7 @@ INSERT INTO data.type(typePK, typeID, description, unit, scale, display) VALUES(
 INSERT INTO data.type(typePK, typeID, description, unit, scale, display) VALUES(2, 'latency.weak', 'latency weak motion data', 'ms', 1.0, 'ms');
 INSERT INTO data.type(typePK, typeID, description, unit, scale, display) VALUES(3, 'latency.gnss.1hz', 'latency GNSS 1Hz data', 'ms', 1.0, 'ms');
 INSERT INTO data.type(typePK, typeID, description, unit, scale, display) VALUES(4, 'latency.tsunami', 'latency tsunami data', 'ms', 1.0, 'ms');
+INSERT INTO data.type(typePK, typeID, description, unit, scale, display) VALUES(5, 'latency.files.gnss', 'latency files data', 'ms', 1.0, 'ms');
 
 CREATE TABLE data.latency (
   sitePK INTEGER REFERENCES data.site(sitePK) ON DELETE CASCADE NOT NULL,
@@ -86,7 +87,7 @@ CREATE TABLE data.completeness_type (
   expected INTEGER NOT NULL
 );
 
-INSERT INTO data.completeness_type(typePK, typeID, expected) VALUES(100, 'gnss.1hz', 86400);
+INSERT INTO data.completeness_type(typePK, typeID, expected) VALUES(100, 'completeness.gnss.1hz', 86400);
 
 CREATE TABLE data.completeness (
   sitePK INTEGER REFERENCES data.site(sitePK) ON DELETE CASCADE NOT NULL,

--- a/mtr-api/routes_test.go
+++ b/mtr-api/routes_test.go
@@ -256,9 +256,9 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/data/latency/threshold?typeID=latency.strong&siteID=TAUP&typeID=latency.strong", Accept: "application/x-protobuf"},
 
 	// Delete data.completeness
-	{ID: wt.L(), URL: "/data/completeness?siteID=WGTN&typeID=gnss.1hz&time=2015-05-14T23:40:30Z&count=300", Method: "PUT"},
-	{ID: wt.L(), URL: "/data/completeness?siteID=WGTN&typeID=gnss.1hz", Method: "DELETE"},
-	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&time=2015-05-14T23:40:30Z&count=300", Method: "PUT"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=WGTN&typeID=completeness.gnss.1hz&time=2015-05-14T23:40:30Z&count=300", Method: "PUT"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=WGTN&typeID=completeness.gnss.1hz", Method: "DELETE"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=completeness.gnss.1hz&time=2015-05-14T23:40:30Z&count=300", Method: "PUT"},
 
 	// Tags
 	{ID: wt.L(), URL: "/tag/FRED", Method: "DELETE"},
@@ -277,7 +277,7 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/data/latency/tag?siteID=TAUP&typeID=latency.strong&tag=TAUP", Method: "PUT"},
 
 	// Create a tag on a completeness
-	{ID: wt.L(), URL: "/data/completeness/tag?siteID=TAUP&typeID=gnss.1hz&tag=TAUP", Method: "PUT"},
+	{ID: wt.L(), URL: "/data/completeness/tag?siteID=TAUP&typeID=completeness.gnss.1hz&tag=TAUP", Method: "PUT"},
 
 	// protobuf of all tagged data latencies
 	{ID: wt.L(), URL: "/data/latency/tag", Accept: "application/x-protobuf"},
@@ -304,11 +304,11 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/data/latency?siteID=TAUP&typeID=latency.strong&resolution=hour", Accept: "application/x-protobuf"},
 
 	// Completeness plots.
-	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=five_minutes"},
-	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=hour"},
-	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=twelve_hours"},
-	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&plot=spark"},
-	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=gnss.1hz&resolution=five_minutes&plot=scatter"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=completeness.gnss.1hz&resolution=five_minutes"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=completeness.gnss.1hz&resolution=hour"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=completeness.gnss.1hz&resolution=twelve_hours"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=completeness.gnss.1hz&plot=spark"},
+	{ID: wt.L(), URL: "/data/completeness?siteID=TAUP&typeID=completeness.gnss.1hz&resolution=five_minutes&plot=scatter"},
 
 	// Tags
 	{ID: wt.L(), URL: "/tag/LINZ", Method: "DELETE"},
@@ -441,7 +441,7 @@ func TestPlotData(t *testing.T) {
 			}
 		}
 
-		r.URL = fmt.Sprintf("/data/completeness?siteID=TAUP&typeID=gnss.1hz&time=%s&count=%d",
+		r.URL = fmt.Sprintf("/data/completeness?siteID=TAUP&typeID=completeness.gnss.1hz&time=%s&count=%d",
 			now.Add(time.Duration(i)*time.Minute).Format(time.RFC3339), v)
 
 		if _, err = r.Do(testServer.URL); err != nil {
@@ -836,7 +836,7 @@ func TestDataCompletenessSummary(t *testing.T) {
 		t.Error("unexpected zero seconds")
 	}
 
-	r.URL = "/data/completeness/summary?typeID=gnss.1hz"
+	r.URL = "/data/completeness/summary?typeID=completeness.gnss.1hz"
 
 	if b, err = r.Do(testServer.URL); err != nil {
 		t.Error(err)

--- a/mtr-api/routes_test.go
+++ b/mtr-api/routes_test.go
@@ -828,7 +828,7 @@ func TestDataCompletenessSummary(t *testing.T) {
 		t.Errorf("expected TAUP got %s", d.SiteID)
 	}
 
-	if d.TypeID != "gnss.1hz" {
+	if d.TypeID != "completeness.gnss.1hz" {
 		t.Errorf("expected gnss.1hz got %s", d.TypeID)
 	}
 
@@ -1373,12 +1373,12 @@ func TestDataTypes(t *testing.T) {
 		t.Error("got nil for /data/type protobuf")
 	}
 
-	if len(dtr.Result) != 4 {
-		t.Errorf("expected 4 results, got %d.", len(dtr.Result))
+	if len(dtr.Result) != 5 {
+		t.Errorf("expected 5 results, got %d.", len(dtr.Result))
 	}
 
-	if dtr.Result[0].TypeID != "latency.gnss.1hz" {
-		t.Errorf("expected latency.gnss.1hz got %s", dtr.Result[0].TypeID)
+	if dtr.Result[0].TypeID != "latency.files.gnss" {
+		t.Errorf("expected latency.files.gnss got %s", dtr.Result[0].TypeID)
 	}
 
 	if dtr.Result[0].Display != "ms" {

--- a/mtr-ui/routes_test.go
+++ b/mtr-ui/routes_test.go
@@ -31,10 +31,10 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/data/metrics?typeID=latency.gnss.1hz&status=good"},
 	{ID: wt.L(), URL: "/data/metrics?&status=good"},
 	// data completeness
-	{ID: wt.L(), URL: "/data/completeness/plot?typeID=gnss.1hz&siteID=TAUP"},
-	{ID: wt.L(), URL: "/data/completeness/plot?typeID=gnss.1hz&siteID=TAUP&resolution=five_minutes"},
-	{ID: wt.L(), URL: "/data/completeness/plot?typeID=gnss.1hz&siteID=TAUP&resolution=hour"},
-	{ID: wt.L(), URL: "/data/completeness/plot?typeID=gnss.1hz&siteID=TAUP&resolution=twelve_hours"},
+	{ID: wt.L(), URL: "/data/completeness/plot?typeID=completeness.gnss.1hz&siteID=TAUP"},
+	{ID: wt.L(), URL: "/data/completeness/plot?typeID=completeness.gnss.1hz&siteID=TAUP&resolution=five_minutes"},
+	{ID: wt.L(), URL: "/data/completeness/plot?typeID=completeness.gnss.1hz&siteID=TAUP&resolution=hour"},
+	{ID: wt.L(), URL: "/data/completeness/plot?typeID=completeness.gnss.1hz&siteID=TAUP&resolution=twelve_hours"},
 
 	// field pages
 	{ID: wt.L(), URL: "/field/"},


### PR DESCRIPTION
…leteness.gnss.1hz'.

Note: For data.completeness_type we can simply change the typeID from "gnss.1hz" to "completeness.gnss.1hz".

<!---
@huboard:{"order":233.0,"milestone_order":233,"custom_state":""}
-->
