### PR TITLE
Reenable svg plots

### DIFF
--- a/mtr-ui/app_page.go
+++ b/mtr-ui/app_page.go
@@ -55,7 +55,7 @@ func appPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Resul
 func appPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
 	var err error
 
-	if res := weft.CheckQuery(r, []string{"applicationID"}, []string{"resolution"}); !res.Ok {
+	if res := weft.CheckQuery(r, []string{"applicationID"}, []string{"resolution", "interactive"}); !res.Ok {
 		return res
 	}
 
@@ -68,8 +68,9 @@ func appPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.R
 	// get the applicationID and resolution params from the URL
 	p.pageParam(r.URL.Query())
 
-	if p.Resolution == "" {
-		p.Resolution = "hour"
+	// Resolution not required if we're in "interactive" mode otherwise default is minute
+	if p.Resolution == "" && !p.Interactive {
+		p.Resolution = "minute"
 	}
 
 	if err = p.populateTags(); err != nil {

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -1,3 +1,5 @@
+"use strict";
+
 function utcToLocal(x) {
 	return Date.parse(x) - new Date().getTimezoneOffset()*60*1000;
 }

--- a/mtr-ui/assets/js/graph.js
+++ b/mtr-ui/assets/js/graph.js
@@ -1,5 +1,3 @@
-"use strict";
-
 function utcToLocal(x) {
 	return Date.parse(x) - new Date().getTimezoneOffset()*60*1000;
 }

--- a/mtr-ui/assets/tmpl/app_plot.html
+++ b/mtr-ui/assets/tmpl/app_plot.html
@@ -4,6 +4,7 @@
 
 <div class="row">
     <div class="col-xs-12 col-md-12">
+        {{if .Interactive}}
         <div id="graphdiv" class="graph">
             <script>
                 $(document).ready(function () {
@@ -97,6 +98,24 @@
 
             </script>
         </div>
+        {{template "app_plot_res" .}}
+
+        {{else}}
+        <img src="{{.MtrApiUrl}}/app/metric?applicationID={{.ApplicationID}}&group=counters&resolution={{.Resolution}}" />
+        {{template "app_plot_res" .}}
+        <br>
+        <img src="{{.MtrApiUrl}}/app/metric?applicationID={{.ApplicationID}}&group=timers&resolution={{.Resolution}}" />
+        {{template "app_plot_res" .}}
+        <br>
+        <img src="{{.MtrApiUrl}}/app/metric?applicationID={{.ApplicationID}}&group=memory&resolution={{.Resolution}}" />
+        {{template "app_plot_res" .}}
+        <br>
+        <img src="{{.MtrApiUrl}}/app/metric?applicationID={{.ApplicationID}}&group=routines&resolution={{.Resolution}}" />
+        {{template "app_plot_res" .}}
+        <br>
+        <img src="{{.MtrApiUrl}}/app/metric?applicationID={{.ApplicationID}}&group=objects&resolution={{.Resolution}}" />
+        {{template "app_plot_res" .}}
+        {{end}}
     </div>
 </div>
 {{end}}

--- a/mtr-ui/assets/tmpl/border.html
+++ b/mtr-ui/assets/tmpl/border.html
@@ -10,9 +10,11 @@
     <link rel="stylesheet" href="//static.geonet.org.nz/bootstrap/3.3.6/css/bootstrap.min.css">
     <link rel="stylesheet" href="//static.geonet.org.nz/leaflet/0.7.7/leaflet.css">
 
+    {{ if .Interactive }}
     <script src="//static.geonet.org.nz/jquery/js/jquery-1.11.3.min.js"></script>
     <script src="//static.geonet.org.nz/dygraph/1.1.1/dygraph-combined.js"></script>
     <script src="/js/graph.js"></script>
+    {{end}}
 
     <style>
 		.footer {

--- a/mtr-ui/assets/tmpl/border.html
+++ b/mtr-ui/assets/tmpl/border.html
@@ -10,10 +10,14 @@
     <link rel="stylesheet" href="//static.geonet.org.nz/bootstrap/3.3.6/css/bootstrap.min.css">
     <link rel="stylesheet" href="//static.geonet.org.nz/leaflet/0.7.7/leaflet.css">
 
-    {{ if .Interactive }}
+    <!--jquery needed by many js libs so load synchronously. Defer attr loads at end and maintains order, async does not-->
     <script src="//static.geonet.org.nz/jquery/js/jquery-1.11.3.min.js"></script>
-    <script src="//static.geonet.org.nz/dygraph/1.1.1/dygraph-combined.js"></script>
-    <script src="/js/graph.js"></script>
+    <script defer src="//static.geonet.org.nz/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <script defer src="//static.geonet.org.nz/leaflet/0.7.7/leaflet.js"></script>
+    <script defer src="/js/leaflet-patch180.js"></script>
+    {{ if .Interactive }}
+    <script defer src="//static.geonet.org.nz/dygraph/1.1.1/dygraph-combined.js"></script>
+    <script defer src="/js/graph.js"></script>
     {{end}}
 
     <style>
@@ -214,9 +218,6 @@
 
         </div>
     </div>
-    <script src="//static.geonet.org.nz/bootstrap/3.3.6/js/bootstrap.min.js"></script>
-    <script src="//static.geonet.org.nz/leaflet/0.7.7/leaflet.js"></script>
-    <script src="/js/leaflet-patch180.js"></script>
     <script type="text/javascript">
         $(document).keypress(function(e) {
             if(!$('#search_query').is(':focus')) {

--- a/mtr-ui/assets/tmpl/components.html
+++ b/mtr-ui/assets/tmpl/components.html
@@ -190,7 +190,7 @@
         {{else}}
         <img src="{{.MtrApiUrl}}/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/>
 
-        {{if .FieldLog}}
+        {{if and .FieldLog (not .Interactive)}}
         <div class="row">
             <div class="col-xs-12 col-md-12">
                 {{$upper:=.FieldLog.Upper}}
@@ -218,14 +218,7 @@
             <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
             <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
             <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
-        </ul>
-    </div>
-    <div class="col-xs-12 col-md-12">
-        <ul class="nav nav-pills">
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=hour">28 Days</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=full">All Data</a></li>
+            <li role="presentation" {{if .Interactive}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true">Interactive</a></li>
         </ul>
     </div>
 </div>
@@ -239,14 +232,7 @@
             <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=minute">SVG 12 Hours</a></li>
             <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=five_minutes">48 Hours</a></li>
             <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=hour">28 Days</a></li>
-        </ul>
-    </div>
-    <div class="col-xs-12 col-md-12">
-        <ul class="nav nav-pills">
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=hour">28 Days</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=full">All Data</a></li>
+            <li role="presentation" {{if .Interactive}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true">Interactive</a></li>
         </ul>
     </div>
 </div>
@@ -300,7 +286,7 @@
 
     <div class="col-xs-12 col-md-12"><img src="{{.MtrApiUrl}}/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/></div>
 
-    {{if .LatencyLog}}
+    {{if and .LatencyLog (not .Interactive)}}
     <div class="row">
         <div class="col-xs-12 col-md-12">
             {{$upper:=.LatencyLog.Upper}}
@@ -329,14 +315,7 @@
             <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
             <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
             <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
-        </ul>
-    </div>
-    <div class="col-xs-12 col-md-12">
-        <ul class="nav nav-pills">
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=hour">28 Days</a></li>
-            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=full">All Data</a></li>
+            <li role="presentation" {{if .Interactive}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true">Interactive</a></li>
         </ul>
     </div>
 </div>

--- a/mtr-ui/assets/tmpl/components.html
+++ b/mtr-ui/assets/tmpl/components.html
@@ -155,6 +155,7 @@
 {{end}}
 <div class="row">
     <div class="col-xs-12 col-md-12">
+        {{if .Interactive}}
         <div id="graphdiv" class="graph">
             <script type="text/javascript">
                 $(document).ready(function () {
@@ -186,6 +187,67 @@
                 });
             </script>
         </div>
+        {{else}}
+        <img src="{{.MtrApiUrl}}/field/metric?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/>
+
+        {{if .FieldLog}}
+        <div class="row">
+            <div class="col-xs-12 col-md-12">
+                {{$upper:=.FieldLog.Upper}}
+                {{$lower:=.FieldLog.Lower}}
+                <h4>Upper:{{$upper}}, Lower:{{$lower}}</h4>
+                <table class="history-log">
+                    <thead><tr><th>time</th><th>value</th></tr></thead>
+                    <tbody>
+                    {{range .FieldLog.Result}}
+                    <tr style="color:{{fieldColour . $lower $upper}}">
+                        <td>{{rfc3339str .Seconds}}</td><td>{{.Value}}</td>
+                    </tr>
+                    {{end}}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {{end}}
+        {{end}}
+    </div>
+</div>
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
+        </ul>
+    </div>
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/field/plot?deviceID={{urlquery .DeviceID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=full">All Data</a></li>
+        </ul>
+    </div>
+</div>
+
+{{end}}
+
+{{define "app_plot_res"}}
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=minute">SVG 12 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&resolution=hour">28 Days</a></li>
+        </ul>
+    </div>
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/app/plot?applicationID={{.ApplicationID}}&interactive=true&resolution=full">All Data</a></li>
+        </ul>
     </div>
 </div>
 {{end}}
@@ -204,6 +266,9 @@
 </div>
 {{end}}
 <div class="row">
+
+    {{if .Interactive }}
+
     <br>
     <div class="graph col-xs-12 col-md-12" id="graphdiv"></div>
     <script>
@@ -230,7 +295,52 @@
                     {{if .Plt.Thresholds}}[{{index .Plt.Thresholds 0}}, {{index .Plt.Thresholds 1}}]{{else}}null{{end}});
         });
     </script>
+
+    {{else}}
+
+    <div class="col-xs-12 col-md-12"><img src="{{.MtrApiUrl}}/data/latency?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution={{.Resolution}}"/></div>
+
+    {{if .LatencyLog}}
+    <div class="row">
+        <div class="col-xs-12 col-md-12">
+            {{$upper:=.LatencyLog.Upper}}
+            {{$lower:=.LatencyLog.Lower}}
+            <h4>Upper:{{$upper}}, Lower:{{$lower}}</h4>
+            <table class="history-log">
+                <thead><tr><th>time</th><th>mean</th><th>fifty</th><th>ninety</th></tr></thead>
+                <tbody>
+                {{range .LatencyLog.Result}}
+                <tr style="color:{{latencyColour . $lower $upper}}">
+                    <td>{{rfc3339str .Seconds}}</td><td>{{.Mean}}</td><td>{{.Fifty}}</td><td>{{.Ninety}}</td>
+                </tr>
+                {{end}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+    {{end}}
+
+    {{end}}
+
 </div>
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (eq .Resolution "minute") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=minute">12 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "five_minutes") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (eq .Resolution "hour") (not .Interactive)}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&resolution=hour">28 Days</a></li>
+        </ul>
+    </div>
+    <div class="col-xs-12 col-md-12">
+        <ul class="nav nav-pills">
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "minute")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=minute">Interactive 12 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "five_minutes")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=five_minutes">48 Hours</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "hour")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=hour">28 Days</a></li>
+            <li role="presentation" {{if and (.Interactive) (eq .Resolution "full")}}class="active"{{end}}><a href="/data/plot?siteID={{urlquery .SiteID}}&typeID={{urlquery .TypeID}}&interactive=true&resolution=full">All Data</a></li>
+        </ul>
+    </div>
+</div>
+
 {{end}}
 
 {{define "data_completeness_plot"}}

--- a/mtr-ui/data_page.go
+++ b/mtr-ui/data_page.go
@@ -118,7 +118,7 @@ func dataSitesPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft
 }
 
 func dataPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"resolution"}); !res.Ok {
+	if res := weft.CheckQuery(r, []string{"siteID", "typeID"}, []string{"resolution", "interactive"}); !res.Ok {
 		return res
 	}
 
@@ -136,8 +136,9 @@ func dataPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.
 		return weft.InternalServerError(err)
 	}
 
-	if p.Resolution == "" {
-		p.Resolution = "hour"
+	// Resolution not required if we're in "interactive" mode otherwise default is minute
+	if p.Resolution == "" && !p.Interactive {
+		p.Resolution = "minute"
 	}
 
 	if err := p.getLatencyHistoryLog(); err != nil {

--- a/mtr-ui/field_page.go
+++ b/mtr-ui/field_page.go
@@ -119,7 +119,7 @@ func fieldDevicesPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *w
 }
 
 func fieldPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {
-	if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution"}); !res.Ok {
+	if res := weft.CheckQuery(r, []string{"deviceID", "typeID"}, []string{"resolution", "interactive"}); !res.Ok {
 		return res
 	}
 	p := mtrUiPage{}
@@ -133,8 +133,9 @@ func fieldPlotPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft
 		return weft.InternalServerError(err)
 	}
 
-	if p.Resolution == "" {
-		p.Resolution = "hour"
+	// Resolution not required if we're in "interactive" mode otherwise default is minute
+	if p.Resolution == "" && !p.Interactive {
+		p.Resolution = "minute"
 	}
 
 	if err := p.getFieldHistoryLog(); err != nil {

--- a/mtr-ui/map_page.go
+++ b/mtr-ui/map_page.go
@@ -10,10 +10,11 @@ import (
 
 type mapPage struct {
 	page
-	ActiveTab string
-	MtrApiUrl string
-	TypeID    string
-	MapApiUrl string
+	ActiveTab   string
+	MtrApiUrl   string
+	TypeID      string
+	MapApiUrl   string
+	Interactive bool
 }
 
 func mapPageHandler(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result {

--- a/mtr-ui/metric_handler.go
+++ b/mtr-ui/metric_handler.go
@@ -12,6 +12,7 @@ type metricDetailPage struct {
 	page
 	MtrApiUrl    *url.URL
 	MetricDetail metricDetail
+	Interactive  bool
 }
 
 type metricDetail struct {

--- a/mtr-ui/routes_test.go
+++ b/mtr-ui/routes_test.go
@@ -26,6 +26,7 @@ var routes = wt.Requests{
 	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&resolution=minute"},
 	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&resolution=five_minutes"},
 	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&resolution=hour"},
+	{ID: wt.L(), URL: "/data/plot?siteID=CHTI&typeID=latency.gnss.1hz&interactive=true"},
 	{ID: wt.L(), URL: "/data/metrics"},
 	{ID: wt.L(), URL: "/data/metrics?typeID=latency.gnss.1hz"},
 	{ID: wt.L(), URL: "/data/metrics?typeID=latency.gnss.1hz&status=good"},

--- a/mtr-ui/search.go
+++ b/mtr-ui/search.go
@@ -16,6 +16,7 @@ type searchPage struct {
 	MtrApiUrl       *url.URL
 	TagName         string
 	MatchingMetrics matchingMetrics
+	Interactive     bool
 }
 
 type matchingMetrics []metricInfo

--- a/mtr-ui/tag_page.go
+++ b/mtr-ui/tag_page.go
@@ -9,10 +9,11 @@ import (
 
 type tagPage struct {
 	page
-	ActiveTab string
-	Path      string
-	TagTabs   []string
-	Tags      []string
+	ActiveTab   string
+	Path        string
+	TagTabs     []string
+	Tags        []string
+	Interactive bool
 }
 
 var tagGrouper = []string{"ABC", "DEF", "GHI", "JKL", "MNO", "POR", "STU", "VWXYZ", "0123456789"}

--- a/mtr-ui/ui_page.go
+++ b/mtr-ui/ui_page.go
@@ -23,6 +23,7 @@ type mtrUiPage struct {
 	Resolution    string
 	Plt           plotInfo
 	Tags          []string
+	Interactive   bool
 	fieldResult   []*mtrpb.FieldMetricSummary
 	dataResult    []*mtrpb.DataLatencySummary
 	FieldLog      *mtrpb.FieldMetricResult
@@ -131,6 +132,7 @@ func (p *mtrUiPage) pageParam(q url.Values) int {
 
 	p.Resolution = q.Get("resolution")
 
+	p.Interactive = q.Get("interactive") == "true"
 	return n
 }
 


### PR DESCRIPTION
Bringing SVG plots back for mtr-ui.  They're the default for all plots in this branch but we may want to modify that.  Buttons exist for 12 hours, 48 hours, 28 days and the interactive plot (with progressive loading).

I did some research on including JS code in head (blocking) vs the bottom portion of body, or using async or defer.  I settled on including jquery normally (blocking) since it's needed by several other libs, and using the defer attribute to load all other js libs.  Google's performance tools also suggested we look into setting the cache control of our JS objects.  This is getting a bit pedantic for mtr but it's useful for me to understand how these things work.
