### PR TITLE
Soh

### DIFF
--- a/mtr-api/routes_test.go
+++ b/mtr-api/routes_test.go
@@ -325,6 +325,10 @@ var routes = wt.Requests{
 
 	// Delete a tag on a metric
 	{ID: wt.L(), URL: "/field/metric/tag?deviceID=gps-taupoairport&typeID=voltage&tag=LINZ", Method: "DELETE"},
+
+	// soh routes
+	{ID: wt.L(), URL: "/soh"},
+	{ID: wt.L(), URL: "/soh/up"},
 }
 
 // Test all routes give the expected response.  Also check with

--- a/mtr-ui/routes_test.go
+++ b/mtr-ui/routes_test.go
@@ -68,6 +68,10 @@ var routes = wt.Requests{
 	// search
 	{ID: wt.L(), URL: "/search?tagQuery=TAKP"},
 	{ID: wt.L(), URL: "/search?tagQuery=TAKP&page=1"},
+
+	// soh routes
+	{ID: wt.L(), URL: "/soh"},
+	{ID: wt.L(), URL: "/soh/up"},
 }
 
 func setup() {


### PR DESCRIPTION
This adds soh routes:

* /soh for external service status probing (server density at the moment)
* /soh/up for use with aws load balancers so that they can insert the container as soon as it's started.
* removes the use of weft from the existing soh routes.

They don't use weft as there is not point in having these in our app metrics. This means there is a little bit of header setting that usually happens in weft.

I plan to add these to all our web projects (consistently).