### PR TITLE
Making X axis for App SVGs 2 days instead of 3 when resolution is 48H…

### DIFF
--- a/mtr-api/app_metric.go
+++ b/mtr-api/app_metric.go
@@ -187,7 +187,7 @@ func appMetricSvg(r *http.Request, h http.Header, b *bytes.Buffer) *weft.Result 
 		p.SetXAxis(time.Now().UTC().Add(time.Hour*-12), time.Now().UTC())
 		p.SetXLabel("12 hours")
 	case "five_minutes":
-		p.SetXAxis(time.Now().UTC().Add(time.Hour*-24*3), time.Now().UTC())
+		p.SetXAxis(time.Now().UTC().Add(time.Hour*-24*2), time.Now().UTC())
 		p.SetXLabel("48 hours")
 	case "hour":
 		p.SetXAxis(time.Now().UTC().Add(time.Hour*-24*28), time.Now().UTC())


### PR DESCRIPTION
This appears to be a typo, 3 instead of 2 days for the 48 hour plot.

I haven't tested this locally since I can't get 48 hours of test data very easily for these app plots.  The tests run OK but don't seem to exercise these plots very much.  I can't find any other reference to time.Hour*-24*3 in mtr-api.

Resolves GeoNet/mtr#241