### PR TITLE
Bumped golang to version 1.7.3 in build.sh and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: go
 go:
-  - 1.7
+  - 1.7.3
 
 services:
   - docker

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ if [ $# -eq 0 ]; then
 fi
 
 # code will be compiled in this container
-BUILD_CONTAINER=golang:1.7.0-alpine
+BUILD_CONTAINER=golang:1.7.3-alpine
 
 DOCKER_TMP=docker-build-tmp
 


### PR DESCRIPTION
Travis uses gimme (https://github.com/travis-ci/gimme) to manage Go versions.  I experimented with this and it appears that downloading Go 1.7 with gimme downloads 1.7.0 instead of the latest (currently 1.7.3).  We could use 'master' but that seems a bit too variable to me, it uses the master build instead of a release.  Using specific versions here seems to be the best option.